### PR TITLE
Better class naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ This package provides two functionalities:
 
 ## Usage
 
-Initialise the manager providing an instance of `SQLAlchemyBindConfig`
+Initialise the manager providing an instance of `SQLAlchemyConfig`
 
 ```python
-from sqlalchemy_bind_manager import SQLAlchemyBindConfig, SQLAlchemyBindManager
+from sqlalchemy_bind_manager import SQLAlchemyConfig, SQLAlchemyBindManager
 
-config = SQLAlchemyBindConfig(
+config = SQLAlchemyConfig(
     engine_url="sqlite:///./sqlite.db",
     engine_options=dict(connect_args={"check_same_thread": False}, echo=True),
     session_options=dict(expire_on_commit=False),
@@ -92,15 +92,15 @@ with sa_manager.get_session() as session:
 `SQLAlchemyBindManager` accepts also multiple databases configuration, provided as a dictionary. The dictionary keys are used as a reference name for each bind.
 
 ```python
-from sqlalchemy_bind_manager import SQLAlchemyBindConfig, SQLAlchemyBindManager
+from sqlalchemy_bind_manager import SQLAlchemyConfig, SQLAlchemyBindManager
 
 config = {
-    "default": SQLAlchemyBindConfig(
+    "default": SQLAlchemyConfig(
         engine_url="sqlite:///./sqlite.db",
         engine_options=dict(connect_args={"check_same_thread": False}, echo=True),
         session_options=dict(expire_on_commit=False),
     ),
-    "secondary": SQLAlchemyBindConfig(
+    "secondary": SQLAlchemyConfig(
         engine_url="sqlite:///./secondary.db",
         engine_options=dict(connect_args={"check_same_thread": False}, echo=True),
         session_options=dict(expire_on_commit=False),
@@ -133,7 +133,7 @@ chapter to avoid issues.
 Is it possible to supply configurations for asyncio supported engines.
 
 ```python
-config = SQLAlchemyAsyncBindConfig(
+config = SQLAlchemyAsyncConfig(
     engine_url="postgresql+asyncpg://scott:tiger@localhost/test",
 )
 ```
@@ -151,16 +151,19 @@ to check [SQLAlchemy asyncio documentation](https://docs.sqlalchemy.org/en/20/or
 
 ## Repository
 
-The `SQLAlchemySyncRepository` and `SQLAlchemyAsyncRepository` class can be used simply by extending them.
+The `SQLAlchemyRepository` and `SQLAlchemyAsyncRepository` class can be used simply by extending them.
 
 ```python
-from sqlalchemy_bind_manager import SQLAlchemySyncRepository
+from sqlalchemy_bind_manager import SQLAlchemyRepository
+
 
 class MyModel(model_declarative_base):
     pass
 
-class ModelRepository(SQLAlchemySyncRepository[MyModel]):
+
+class ModelRepository(SQLAlchemyRepository[MyModel]):
     _model = MyModel
+
 
 repo_instance = ModelRepository(sqlalchemy_bind_manager.get_bind())
 ```
@@ -204,7 +207,7 @@ It is possible we need to run several operations in a single database transactio
 repository provide by itself an isolated session for single operations, we have to use a different
 approach for multiple operations.
 
-We can use the `SASyncUnitOfWork` or the `SASyncUnitOfWork` class to provide a shared session to
+We can use the `SQLAlchemyUnitOfWork` or the `SQLAlchemyUnitOfWork` class to provide a shared session to
 be used for repository operations, **assumed the same bind is used for all the repositories**.
 (Two phase transactions are not currently supported).
 
@@ -215,7 +218,7 @@ operations to bypass the internal repository-managed session.
 bind = sa_manager.get_bind()
 repo1 = MyRepo(bind)
 repo2 = MyOtherRepo(bind)
-uow = SASyncUnitOfWork(bind)
+uow = SQLAlchemyUnitOfWork(bind)
 
 with uow.get_session() as _session:
     repo1.save(some_model, session=_session)

--- a/sqlalchemy_bind_manager/__init__.py
+++ b/sqlalchemy_bind_manager/__init__.py
@@ -2,8 +2,6 @@ from ._bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyAsyncConfig,
     SQLAlchemyConfig,
-    SQLAlchemyBind,
-    _SQLAlchemyConfig,
 )
 from ._repository import (
     SQLAlchemyRepository,

--- a/sqlalchemy_bind_manager/__init__.py
+++ b/sqlalchemy_bind_manager/__init__.py
@@ -1,16 +1,16 @@
 from ._bind_manager import (
     SQLAlchemyBindManager,
-    SQLAlchemyAsyncBindConfig,
-    SQLAlchemyBindConfig,
-    SQLAlchemyBind,
+    SQLAlchemyAsyncConfig,
     SQLAlchemyConfig,
+    SQLAlchemyBind,
+    _SQLAlchemyConfig,
 )
 from ._repository import (
-    SQLAlchemySyncRepository,
+    SQLAlchemyRepository,
     SQLAlchemyAsyncRepository,
     SortDirection,
 )
 from ._unit_of_work import (
-    SASyncUnitOfWork,
-    SAAsyncUnitOfWork,
+    SQLAlchemyUnitOfWork,
+    SQLAlchemyAsyncUnitOfWork,
 )

--- a/sqlalchemy_bind_manager/_bind_manager.py
+++ b/sqlalchemy_bind_manager/_bind_manager.py
@@ -18,13 +18,13 @@ from sqlalchemy_bind_manager.exceptions import (
 )
 
 
-class SQLAlchemyBindConfig(BaseModel):
+class SQLAlchemyConfig(BaseModel):
     engine_options: Union[dict, None]
     engine_url: str
     session_options: Union[dict, None]
 
 
-class SQLAlchemyAsyncBindConfig(BaseModel):
+class SQLAlchemyAsyncConfig(BaseModel):
     engine_options: Union[dict, None]
     engine_url: str
     session_options: Union[dict, None]
@@ -50,10 +50,10 @@ class SQLAlchemyAsyncBind(BaseModel):
         arbitrary_types_allowed = True
 
 
-SQLAlchemyConfig = Union[
-    Mapping[str, Union[SQLAlchemyBindConfig, SQLAlchemyAsyncBindConfig]],
-    SQLAlchemyBindConfig,
-    SQLAlchemyAsyncBindConfig,
+_SQLAlchemyConfig = Union[
+    Mapping[str, Union[SQLAlchemyConfig, SQLAlchemyAsyncConfig]],
+    SQLAlchemyConfig,
+    SQLAlchemyAsyncConfig,
 ]
 DEFAULT_BIND_NAME = "default"
 
@@ -63,7 +63,7 @@ class SQLAlchemyBindManager:
 
     def __init__(
         self,
-        config: SQLAlchemyConfig,
+        config: _SQLAlchemyConfig,
     ) -> None:
         self.__binds = {}
         if isinstance(config, Mapping):
@@ -73,16 +73,16 @@ class SQLAlchemyBindManager:
             self.__init_bind(DEFAULT_BIND_NAME, config)
 
     def __init_bind(
-        self, name: str, config: Union[SQLAlchemyBindConfig, SQLAlchemyAsyncBindConfig]
+        self, name: str, config: Union[SQLAlchemyConfig, SQLAlchemyAsyncConfig]
     ):
         if not any(
             [
-                isinstance(config, SQLAlchemyBindConfig),
-                isinstance(config, SQLAlchemyAsyncBindConfig),
+                isinstance(config, SQLAlchemyConfig),
+                isinstance(config, SQLAlchemyAsyncConfig),
             ]
         ):
             raise InvalidConfig(
-                f"Config for bind `{name}` is not a SQLAlchemyBindConfig or SQLAlchemyAsyncBindConfig object"
+                f"Config for bind `{name}` is not a SQLAlchemyConfig or SQLAlchemyAsyncConfig object"
             )
 
         engine_options: dict = config.engine_options or {}
@@ -92,7 +92,7 @@ class SQLAlchemyBindManager:
         session_options: dict = config.session_options or {}
         session_options.setdefault("expire_on_commit", False)
 
-        if isinstance(config, SQLAlchemyAsyncBindConfig):
+        if isinstance(config, SQLAlchemyAsyncConfig):
             self.__binds[name] = self.__build_async_bind(
                 engine_url=config.engine_url,
                 engine_options=engine_options,

--- a/sqlalchemy_bind_manager/_repository/__init__.py
+++ b/sqlalchemy_bind_manager/_repository/__init__.py
@@ -1,3 +1,3 @@
-from .sync import SQLAlchemySyncRepository
+from .sync import SQLAlchemyRepository
 from .async_ import SQLAlchemyAsyncRepository
 from .common import SortDirection

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -6,13 +6,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .._bind_manager import SQLAlchemyAsyncBind
-from .._unit_of_work import SAAsyncUnitOfWork
+from .._unit_of_work import SQLAlchemyAsyncUnitOfWork
 from ..exceptions import ModelNotFound
 from .common import MODEL, PRIMARY_KEY, SortDirection, BaseRepository
 
 
 class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
-    _UOW: SAAsyncUnitOfWork
+    _UOW: SQLAlchemyAsyncUnitOfWork
 
     def __init__(self, bind: SQLAlchemyAsyncBind) -> None:
         """
@@ -20,7 +20,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :type bind: SQLAlchemyAsyncBind
         """
         super().__init__()
-        self._UOW = SAAsyncUnitOfWork(bind)
+        self._UOW = SQLAlchemyAsyncUnitOfWork(bind)
 
     @asynccontextmanager
     async def _get_session(

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -6,13 +6,13 @@ from sqlalchemy import select
 from sqlalchemy.orm import scoped_session
 
 from .._bind_manager import SQLAlchemyBind
-from .._unit_of_work import SASyncUnitOfWork
+from .._unit_of_work import SQLAlchemyUnitOfWork
 from ..exceptions import ModelNotFound
 from .common import MODEL, PRIMARY_KEY, SortDirection, BaseRepository
 
 
-class SQLAlchemySyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
-    _UOW: SASyncUnitOfWork
+class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
+    _UOW: SQLAlchemyUnitOfWork
 
     def __init__(self, bind: SQLAlchemyBind) -> None:
         """
@@ -20,7 +20,7 @@ class SQLAlchemySyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :type bind: SQLAlchemyBind
         """
         super().__init__()
-        self._UOW = SASyncUnitOfWork(bind)
+        self._UOW = SQLAlchemyUnitOfWork(bind)
 
     @contextmanager
     def _get_session(

--- a/sqlalchemy_bind_manager/_unit_of_work.py
+++ b/sqlalchemy_bind_manager/_unit_of_work.py
@@ -15,7 +15,7 @@ from sqlalchemy_bind_manager._bind_manager import (
 from sqlalchemy_bind_manager.exceptions import UnsupportedBind
 
 
-class SASyncUnitOfWork:
+class SQLAlchemyUnitOfWork:
     Session: scoped_session
 
     def __init__(self, bind: SQLAlchemyBind):
@@ -50,7 +50,7 @@ class SASyncUnitOfWork:
             raise
 
 
-class SAAsyncUnitOfWork:
+class SQLAlchemyAsyncUnitOfWork:
     Session: async_scoped_session
 
     def __init__(self, bind: SQLAlchemyAsyncBind):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,12 @@ from uuid import uuid4
 
 import pytest
 
-from sqlalchemy_bind_manager import SQLAlchemyBindConfig, SQLAlchemyAsyncBindConfig
+from sqlalchemy_bind_manager import SQLAlchemyConfig, SQLAlchemyAsyncConfig
 
 
 @pytest.fixture
 def single_config():
-    return SQLAlchemyBindConfig(
+    return SQLAlchemyConfig(
         engine_url=f"sqlite:///{uuid4()}.db",
         engine_options=dict(connect_args={"check_same_thread": False}),
     )
@@ -16,11 +16,11 @@ def single_config():
 @pytest.fixture
 def multiple_config():
     return {
-        "default": SQLAlchemyBindConfig(
+        "default": SQLAlchemyConfig(
             engine_url=f"sqlite:///{uuid4()}.db",
             engine_options=dict(connect_args={"check_same_thread": False}),
         ),
-        "async": SQLAlchemyAsyncBindConfig(
+        "async": SQLAlchemyAsyncConfig(
             engine_url=f"sqlite+aiosqlite:///{uuid4()}.db",
             engine_options=dict(connect_args={"check_same_thread": False}),
         ),

--- a/tests/repository/async_/conftest.py
+++ b/tests/repository/async_/conftest.py
@@ -9,14 +9,14 @@ from sqlalchemy.orm import clear_mappers, relationship
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyAsyncRepository,
-    SQLAlchemyAsyncBindConfig,
+    SQLAlchemyAsyncConfig,
 )
 
 
 @pytest.fixture
 def sa_manager() -> SQLAlchemyBindManager:
     test_db_path = f"./{uuid4()}.db"
-    config = SQLAlchemyAsyncBindConfig(
+    config = SQLAlchemyAsyncConfig(
         engine_url=f"sqlite+aiosqlite:///{test_db_path}",
         engine_options=dict(connect_args={"check_same_thread": False}),
         session_options=dict(expire_on_commit=False),

--- a/tests/repository/async_/test_lifecycle.py
+++ b/tests/repository/async_/test_lifecycle.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, AsyncMock
 import pytest
 
 from sqlalchemy_bind_manager import SQLAlchemyAsyncRepository
-from sqlalchemy_bind_manager._unit_of_work import SAAsyncUnitOfWork
+from sqlalchemy_bind_manager._unit_of_work import SQLAlchemyAsyncUnitOfWork
 from sqlalchemy_bind_manager.exceptions import UnsupportedBind
 
 
@@ -107,7 +107,9 @@ async def test_update_model_doesnt_update_other_models_from_same_repo(
     assert updated_model2.name == "SomeoneElse"
 
 
-@patch.object(SAAsyncUnitOfWork, "_commit", return_value=None, new_callable=AsyncMock)
+@patch.object(
+    SQLAlchemyAsyncUnitOfWork, "_commit", return_value=None, new_callable=AsyncMock
+)
 async def test_commit_triggers_once_per_operation_using_internal_uow(
     mocked_uow_commit: AsyncMock, repository_class, model_class, sa_manager
 ):
@@ -126,11 +128,13 @@ async def test_commit_triggers_once_per_operation_using_internal_uow(
     assert mocked_uow_commit.call_count == 2
 
 
-@patch.object(SAAsyncUnitOfWork, "_commit", return_value=None, new_callable=AsyncMock)
+@patch.object(
+    SQLAlchemyAsyncUnitOfWork, "_commit", return_value=None, new_callable=AsyncMock
+)
 async def test_commit_triggers_only_once_with_external_uow(
     mocked_uow_commit: AsyncMock, repository_class, model_class, sa_manager
 ):
-    uow = SAAsyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyAsyncUnitOfWork(sa_manager.get_bind())
     repo1 = repository_class(sa_manager.get_bind())
     repo2 = repository_class(sa_manager.get_bind())
 
@@ -150,7 +154,7 @@ async def test_commit_triggers_only_once_with_external_uow(
 async def test_models_are_persisted_using_external_uow(
     repository_class, model_class, sa_manager
 ):
-    uow = SAAsyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyAsyncUnitOfWork(sa_manager.get_bind())
     repo1 = repository_class(sa_manager.get_bind())
     repo2 = repository_class(sa_manager.get_bind())
 

--- a/tests/repository/conftest.py
+++ b/tests/repository/conftest.py
@@ -6,9 +6,9 @@ import pytest
 from sqlalchemy.orm import clear_mappers
 
 from sqlalchemy_bind_manager import (
-    SQLAlchemyBindConfig,
+    SQLAlchemyConfig,
     SQLAlchemyBindManager,
-    SQLAlchemyAsyncBindConfig,
+    SQLAlchemyAsyncConfig,
 )
 
 
@@ -17,11 +17,11 @@ def sync_async_sa_manager(multiple_config) -> Iterator[SQLAlchemyBindManager]:
     test_sync_db_path = f"./{uuid4()}.db"
     test_async_db_path = f"./{uuid4()}.db"
     config = {
-        "sync": SQLAlchemyBindConfig(
+        "sync": SQLAlchemyConfig(
             engine_url=f"sqlite:///{test_sync_db_path}",
             engine_options=dict(connect_args={"check_same_thread": False}),
         ),
-        "async": SQLAlchemyAsyncBindConfig(
+        "async": SQLAlchemyAsyncConfig(
             engine_url=f"sqlite+aiosqlite:///{test_sync_db_path}",
             engine_options=dict(connect_args={"check_same_thread": False}),
         ),

--- a/tests/repository/sync/conftest.py
+++ b/tests/repository/sync/conftest.py
@@ -8,15 +8,15 @@ from sqlalchemy.orm import clear_mappers, relationship
 
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
-    SQLAlchemySyncRepository,
-    SQLAlchemyBindConfig,
+    SQLAlchemyRepository,
+    SQLAlchemyConfig,
 )
 
 
 @pytest.fixture
 def sa_manager() -> SQLAlchemyBindManager:
     test_db_path = f"./{uuid4()}.db"
-    config = SQLAlchemyBindConfig(
+    config = SQLAlchemyConfig(
         engine_url=f"sqlite:///{test_db_path}",
         engine_options=dict(connect_args={"check_same_thread": False}),
         session_options=dict(expire_on_commit=False),
@@ -31,16 +31,16 @@ def sa_manager() -> SQLAlchemyBindManager:
 
 
 @pytest.fixture
-def repository_class(model_class) -> Type[SQLAlchemySyncRepository]:
-    class MyRepository(SQLAlchemySyncRepository[model_class]):
+def repository_class(model_class) -> Type[SQLAlchemyRepository]:
+    class MyRepository(SQLAlchemyRepository[model_class]):
         _model = model_class
 
     return MyRepository
 
 
 @pytest.fixture
-def related_repository_class(related_model_classes) -> Type[SQLAlchemySyncRepository]:
-    class ParentRepository(SQLAlchemySyncRepository[related_model_classes[0]]):
+def related_repository_class(related_model_classes) -> Type[SQLAlchemyRepository]:
+    class ParentRepository(SQLAlchemyRepository[related_model_classes[0]]):
         _model = related_model_classes[0]
 
     return ParentRepository

--- a/tests/repository/sync/test_lifecycle.py
+++ b/tests/repository/sync/test_lifecycle.py
@@ -2,13 +2,13 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from sqlalchemy_bind_manager import SQLAlchemySyncRepository
-from sqlalchemy_bind_manager._unit_of_work import SASyncUnitOfWork
+from sqlalchemy_bind_manager import SQLAlchemyRepository
+from sqlalchemy_bind_manager._unit_of_work import SQLAlchemyUnitOfWork
 from sqlalchemy_bind_manager.exceptions import UnsupportedBind
 
 
 def test_repository_fails_if_not_sync_bind(sync_async_sa_manager):
-    class SyncRepo(SQLAlchemySyncRepository):
+    class SyncRepo(SQLAlchemyRepository):
         pass
 
     with pytest.raises(UnsupportedBind):
@@ -105,7 +105,7 @@ def test_update_model_doesnt_update_other_models_from_same_repo(
     assert updated_model2.name == "SomeoneElse"
 
 
-@patch.object(SASyncUnitOfWork, "_commit", return_value=None)
+@patch.object(SQLAlchemyUnitOfWork, "_commit", return_value=None)
 def test_commit_triggers_once_per_operation_using_internal_uow(
     mocked_uow_commit: MagicMock, repository_class, model_class, sa_manager
 ):
@@ -124,11 +124,11 @@ def test_commit_triggers_once_per_operation_using_internal_uow(
     assert mocked_uow_commit.call_count == 2
 
 
-@patch.object(SASyncUnitOfWork, "_commit", return_value=None)
+@patch.object(SQLAlchemyUnitOfWork, "_commit", return_value=None)
 def test_commit_triggers_only_once_with_external_uow(
     mocked_uow_commit: MagicMock, repository_class, model_class, sa_manager
 ):
-    uow = SASyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyUnitOfWork(sa_manager.get_bind())
     repo1 = repository_class(sa_manager.get_bind())
     repo2 = repository_class(sa_manager.get_bind())
 
@@ -148,7 +148,7 @@ def test_commit_triggers_only_once_with_external_uow(
 def test_models_are_persisted_using_external_uow(
     repository_class, model_class, sa_manager
 ):
-    uow = SASyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyUnitOfWork(sa_manager.get_bind())
     repo1 = repository_class(sa_manager.get_bind())
     repo2 = repository_class(sa_manager.get_bind())
 

--- a/tests/test_sqlalchemy_bind_manager.py
+++ b/tests/test_sqlalchemy_bind_manager.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import registry, Session
 
 from sqlalchemy_bind_manager import (
-    SQLAlchemyBindConfig,
+    SQLAlchemyConfig,
     SQLAlchemyBindManager,
 )
 from sqlalchemy_bind_manager.exceptions import (
@@ -20,7 +20,7 @@ from sqlalchemy_bind_manager.exceptions import (
     [
         {"bind_name": "Invalid Config"},
         {
-            "valid": SQLAlchemyBindConfig(
+            "valid": SQLAlchemyConfig(
                 engine_url=f"sqlite:///{uuid4}.db",
                 engine_options=dict(connect_args={"check_same_thread": False}),
                 session_options=dict(expire_on_commit=False),

--- a/tests/unit_of_work/async_/conftest.py
+++ b/tests/unit_of_work/async_/conftest.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import clear_mappers
 
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
-    SQLAlchemyAsyncBindConfig,
+    SQLAlchemyAsyncConfig,
     SQLAlchemyAsyncRepository,
 )
 
@@ -16,7 +16,7 @@ from sqlalchemy_bind_manager import (
 @pytest.fixture
 def sa_manager() -> SQLAlchemyBindManager:
     test_db_path = f"./{uuid4()}.db"
-    config = SQLAlchemyAsyncBindConfig(
+    config = SQLAlchemyAsyncConfig(
         engine_url=f"sqlite+aiosqlite:///{test_db_path}",
         engine_options=dict(connect_args={"check_same_thread": False}),
         session_options=dict(expire_on_commit=False),

--- a/tests/unit_of_work/async_/test_session_lifecycle.py
+++ b/tests/unit_of_work/async_/test_session_lifecycle.py
@@ -3,11 +3,11 @@ from unittest.mock import patch, AsyncMock
 import pytest
 from sqlalchemy.ext.asyncio import async_scoped_session
 
-from sqlalchemy_bind_manager._unit_of_work import SAAsyncUnitOfWork
+from sqlalchemy_bind_manager._unit_of_work import SQLAlchemyAsyncUnitOfWork
 
 
 async def test_session_is_destroyed_on_cleanup(sa_manager):
-    uow = SAAsyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyAsyncUnitOfWork(sa_manager.get_bind())
     original_session_remove = uow.Session.remove
 
     with patch.object(
@@ -23,7 +23,7 @@ async def test_session_is_destroyed_on_cleanup(sa_manager):
 
 def test_session_is_destroyed_on_cleanup_if_loop_is_not_running(sa_manager):
     # Running the test without a loop will trigger the loop creation
-    uow = SAAsyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyAsyncUnitOfWork(sa_manager.get_bind())
     original_session_close = uow.Session.remove
 
     with patch.object(
@@ -38,11 +38,11 @@ def test_session_is_destroyed_on_cleanup_if_loop_is_not_running(sa_manager):
 
 
 @pytest.mark.parametrize("commit_flag", [True, False])
-@patch.object(SAAsyncUnitOfWork, "_commit", return_value=None)
+@patch.object(SQLAlchemyAsyncUnitOfWork, "_commit", return_value=None)
 async def test_commit_is_called_only_if_commit(
     mocked_uow_commit: AsyncMock, commit_flag, repository_class, model_class, sa_manager
 ):
-    uow = SAAsyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyAsyncUnitOfWork(sa_manager.get_bind())
     repo1 = repository_class(sa_manager.get_bind())
 
     # Populate a database entry to be used for tests
@@ -60,7 +60,7 @@ async def test_rollback_is_called_if_commit_fails(
     commit_fails,
     sa_manager,
 ):
-    uow = SAAsyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyAsyncUnitOfWork(sa_manager.get_bind())
 
     failure_exception = Exception("Some Error")
     mocked_session = AsyncMock(spec=async_scoped_session)

--- a/tests/unit_of_work/sync/conftest.py
+++ b/tests/unit_of_work/sync/conftest.py
@@ -8,15 +8,15 @@ from sqlalchemy.orm import clear_mappers
 
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
-    SQLAlchemyBindConfig,
-    SQLAlchemySyncRepository,
+    SQLAlchemyConfig,
+    SQLAlchemyRepository,
 )
 
 
 @pytest.fixture
 def sa_manager() -> SQLAlchemyBindManager:
     test_db_path = f"./{uuid4()}.db"
-    config = SQLAlchemyBindConfig(
+    config = SQLAlchemyConfig(
         engine_url=f"sqlite:///{test_db_path}",
         engine_options=dict(connect_args={"check_same_thread": False}),
         session_options=dict(expire_on_commit=False),
@@ -50,8 +50,8 @@ def model_class(sa_manager) -> Type:
 
 
 @pytest.fixture
-def repository_class(model_class) -> Type[SQLAlchemySyncRepository]:
-    class MyRepository(SQLAlchemySyncRepository[model_class]):
+def repository_class(model_class) -> Type[SQLAlchemyRepository]:
+    class MyRepository(SQLAlchemyRepository[model_class]):
         _model = model_class
 
     return MyRepository

--- a/tests/unit_of_work/sync/test_session_lifecycle.py
+++ b/tests/unit_of_work/sync/test_session_lifecycle.py
@@ -3,11 +3,11 @@ from unittest.mock import patch, MagicMock
 import pytest
 from sqlalchemy.orm import scoped_session
 
-from sqlalchemy_bind_manager._unit_of_work import SASyncUnitOfWork
+from sqlalchemy_bind_manager._unit_of_work import SQLAlchemyUnitOfWork
 
 
 def test_session_is_removed_on_cleanup(sa_manager):
-    uow = SASyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyUnitOfWork(sa_manager.get_bind())
     original_session_remove = uow.Session.remove
     with patch.object(
         uow.Session,
@@ -21,11 +21,11 @@ def test_session_is_removed_on_cleanup(sa_manager):
 
 
 @pytest.mark.parametrize("commit_flag", [True, False])
-@patch.object(SASyncUnitOfWork, "_commit", return_value=None)
+@patch.object(SQLAlchemyUnitOfWork, "_commit", return_value=None)
 def test_commit_is_called_only_if_commit(
     mocked_uow_commit: MagicMock, commit_flag, repository_class, model_class, sa_manager
 ):
-    uow = SASyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyUnitOfWork(sa_manager.get_bind())
     repo1 = repository_class(sa_manager.get_bind())
 
     # Populate a database entry to be used for tests
@@ -43,7 +43,7 @@ def test_rollback_is_called_if_commit_fails(
     commit_fails,
     sa_manager,
 ):
-    uow = SASyncUnitOfWork(sa_manager.get_bind())
+    uow = SQLAlchemyUnitOfWork(sa_manager.get_bind())
 
     failure_exception = Exception("Some Error")
     mocked_session = MagicMock(spec=scoped_session)


### PR DESCRIPTION
Rename classes using better naming convention.

Sync Implementation:
- `SQLAlchemyConfig`
- `SQLAlchemyBind`
- `SQLAlchemyUnitOfWork`
- `SQLAlchemyRepository`

Async Implementation:
- `SQLAlchemyAsyncConfig`
- `SQLAlchemyAsyncBind`
- `SQLAlchemyAsyncUnitOfWork`
- `SQLAlchemyAsyncRepository`
