### PR TITLE
Implement cursor based pagination

### DIFF
--- a/.github/workflows/python-3.10.yml
+++ b/.github/workflows/python-3.10.yml
@@ -27,7 +27,7 @@ jobs:
         poetry install --no-root --with dev
     - name: Test with pytest
       run: |
-        pytest
+        make ci-test
     - name: Check typing
       run: |
-        mypy
+        make typing

--- a/.github/workflows/python-3.11.yml
+++ b/.github/workflows/python-3.11.yml
@@ -27,7 +27,7 @@ jobs:
         poetry install --no-root --with dev
     - name: Test with pytest
       run: |
-        pytest
+        make ci-test
     - name: Check typing
       run: |
-        mypy
+        make typing

--- a/.github/workflows/python-3.8.yml
+++ b/.github/workflows/python-3.8.yml
@@ -27,7 +27,7 @@ jobs:
         poetry install --no-root --with dev
     - name: Test with pytest
       run: |
-        pytest
+        make ci-test
     - name: Check typing
       run: |
-        mypy
+        make typing

--- a/.github/workflows/python-3.9.yml
+++ b/.github/workflows/python-3.9.yml
@@ -27,7 +27,7 @@ jobs:
         poetry install --no-root --with dev
     - name: Test with pytest
       run: |
-        pytest
+        make ci-test
     - name: Check typing
       run: |
-        mypy
+        make typing

--- a/.github/workflows/python-code-style.yml
+++ b/.github/workflows/python-code-style.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install poetry
         poetry config virtualenvs.create false
-        poetry install --no-root --with http,grpc,dev
+        poetry install --no-root --with dev
     - name: Check code style with black
       run: |
         black --check sqlalchemy_bind_manager tests

--- a/.github/workflows/python-code-style.yml
+++ b/.github/workflows/python-code-style.yml
@@ -27,4 +27,4 @@ jobs:
         poetry install --no-root --with dev
     - name: Check code style with black
       run: |
-        black --check sqlalchemy_bind_manager tests
+        make format

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -24,6 +24,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install poetry
         poetry config virtualenvs.create false
-        poetry install --no-root --with http,grpc,dev
+        poetry install --no-root --with dev
     - name: Lint with ruff
       uses: chartboost/ruff-action@v1

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -26,4 +26,4 @@ jobs:
         poetry config virtualenvs.create false
         poetry install --no-root --with dev
     - name: Lint with ruff
-      uses: chartboost/ruff-action@v1
+      run: make lint

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -30,7 +30,7 @@ jobs:
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_REPORTER_ID }}
       with:
-        coverageCommand: pytest --cov --cov-report lcov
+        coverageCommand: make ci-coverage
         coverageLocations: |
           ${{github.workspace}}/coverage.lcov:lcov
         debug: true

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ format:
 
 lint:
 	poetry run ruff . --fix
+
+dev-dependencies:
+	poetry update --with dev

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,29 @@
-test: mypy
+test:
 	poetry run pytest -n auto --cov
 
-mypy:
+ci-test:
+	poetry run pytest
+
+ci-coverage:
+	poetry run pytest --cov --cov-report lcov
+
+typing:
 	poetry run mypy
 
 format:
-	poetry run black sqlalchemy_bind_manager tests
+	poetry run black --check sqlalchemy_bind_manager tests
 
 lint:
+	poetry run ruff .
+
+format-fix:
+	poetry run black sqlalchemy_bind_manager tests
+
+lint-fix:
 	poetry run ruff . --fix
 
 dev-dependencies:
 	poetry update --with dev
+
+fix: lint-fix format-fix
+check: typing test lint format

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,5 @@ lint-fix:
 dev-dependencies:
 	poetry update --with dev
 
-fix: lint-fix format-fix
-check: typing test lint format
+fix:  format-fix lint-fix
+check: typing test format lint

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ to check [SQLAlchemy asyncio documentation](https://docs.sqlalchemy.org/en/20/or
 The `SQLAlchemyRepository` and `SQLAlchemyAsyncRepository` class can be used simply by extending them.
 
 ```python
-from sqlalchemy_bind_manager import SQLAlchemyRepository
+from sqlalchemy_bind_manager.repository import SQLAlchemyRepository
 
 
 class MyModel(model_declarative_base):

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The classes provide some common use methods:
 * `delete`: Delete a model
 * `find`: Search for a list of models (basically an adapter for SELECT queries)
 * `paginated_find`: Search for a list of models, with pagination support
+* `cursor_paginated_find`: Search for a list of models, with cursor based pagination support
 
 ### Session lifecycle in repositories
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ testpaths = [
 
 [tool.mypy]
 files = "sqlalchemy_bind_manager"
+plugins = "pydantic.mypy"
 
 [tool.ruff]
 select = ["E", "F", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,4 @@ select = ["E", "F", "I"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
+"repository.py" = ["F401"]

--- a/sqlalchemy_bind_manager/__init__.py
+++ b/sqlalchemy_bind_manager/__init__.py
@@ -3,12 +3,6 @@ from ._bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyConfig,
 )
-from ._repository import (
-    PaginatedResult,
-    SortDirection,
-    SQLAlchemyAsyncRepository,
-    SQLAlchemyRepository,
-)
 from ._unit_of_work import (
     AsyncUnitOfWork,
     UnitOfWork,

--- a/sqlalchemy_bind_manager/__init__.py
+++ b/sqlalchemy_bind_manager/__init__.py
@@ -3,7 +3,3 @@ from ._bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyConfig,
 )
-from ._unit_of_work import (
-    AsyncUnitOfWork,
-    UnitOfWork,
-)

--- a/sqlalchemy_bind_manager/_repository/__init__.py
+++ b/sqlalchemy_bind_manager/_repository/__init__.py
@@ -1,3 +1,3 @@
 from .async_ import SQLAlchemyAsyncRepository
-from .common import PaginatedResult, SortDirection
+from .base_repository import PaginatedResult, SortDirection
 from .sync import SQLAlchemyRepository

--- a/sqlalchemy_bind_manager/_repository/__init__.py
+++ b/sqlalchemy_bind_manager/_repository/__init__.py
@@ -1,4 +1,4 @@
 from .async_ import SQLAlchemyAsyncRepository
 from .base_repository import SortDirection
-from .common import Cursor, CursorPaginatedResult, PaginatedResult
+from .common import CursorPaginatedResult, CursorReference, PaginatedResult
 from .sync import SQLAlchemyRepository

--- a/sqlalchemy_bind_manager/_repository/__init__.py
+++ b/sqlalchemy_bind_manager/_repository/__init__.py
@@ -1,3 +1,4 @@
 from .async_ import SQLAlchemyAsyncRepository
-from .base_repository import PaginatedResult, SortDirection
+from .base_repository import SortDirection
+from .common import Cursor, CursorPaginatedResult, PaginatedResult
 from .sync import SQLAlchemyRepository

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .._bind_manager import SQLAlchemyAsyncBind
 from .._transaction_handler import AsyncSessionHandler
 from ..exceptions import InvalidConfig, ModelNotFound
-from .common import (
+from .base_repository import (
     MODEL,
     PRIMARY_KEY,
     BaseRepository,

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -156,7 +156,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         """
 
         find_stmt = self._find_query(search_params, order_by)
-        paginated_stmt = self._paginate_query(find_stmt, page, per_page)
+        paginated_stmt = self._paginate_query_by_page(find_stmt, page, per_page)
 
         async with self._get_session() as session:
             total_items_count = (
@@ -166,7 +166,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 x for x in (await session.execute(paginated_stmt)).scalars()
             ]
 
-            return self._build_paginated_result(
+            return self._build_paginated_by_page_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -184,7 +184,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, None] = None,
+        reference_cursor: Union[Cursor, str, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -205,6 +205,9 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :return: A collection of models
         :rtype: List
         """
+        if isinstance(reference_cursor, str):
+            reference_cursor = self.decode_cursor(reference_cursor)
+
         find_stmt = self._find_query(search_params)
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -21,7 +21,13 @@ from .base_repository import (
     BaseRepository,
     SortDirection,
 )
-from .common import MODEL, PRIMARY_KEY, Cursor, CursorPaginatedResult, PaginatedResult
+from .common import (
+    MODEL,
+    PRIMARY_KEY,
+    CursorPaginatedResult,
+    CursorReference,
+    PaginatedResult,
+)
 
 
 class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
@@ -180,7 +186,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, str, None] = None,
+        cursor_reference: Union[CursorReference, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -201,13 +207,10 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :return: A collection of models
         :rtype: List
         """
-        if isinstance(reference_cursor, str):
-            reference_cursor = self.decode_cursor(reference_cursor)
-
         find_stmt = self._find_query(search_params)
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,
-            reference_cursor=reference_cursor,
+            cursor_reference=cursor_reference,
             is_end_cursor=is_end_cursor,
             per_page=items_per_page,
         )
@@ -224,6 +227,6 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 result_items=result_items,
                 total_items_count=total_items_count,
                 items_per_page=items_per_page,
-                reference_cursor=reference_cursor,
+                cursor_reference=cursor_reference,
                 is_end_cursor=is_end_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -18,14 +18,10 @@ from .._bind_manager import SQLAlchemyAsyncBind
 from .._transaction_handler import AsyncSessionHandler
 from ..exceptions import InvalidConfig, ModelNotFound
 from .base_repository import (
-    MODEL,
-    PRIMARY_KEY,
     BaseRepository,
-    Cursor,
-    CursorPaginatedResult,
-    PaginatedResult,
     SortDirection,
 )
+from .common import MODEL, PRIMARY_KEY, Cursor, CursorPaginatedResult, PaginatedResult
 
 
 class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -188,7 +188,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         self,
         items_per_page: int,
         cursor_reference: Union[CursorReference, None] = None,
-        is_end_cursor: bool = False,
+        is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         """Find models using filters and cursor based pagination
@@ -212,7 +212,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,
             cursor_reference=cursor_reference,
-            is_end_cursor=is_end_cursor,
+            is_before_cursor=is_before_cursor,
             per_page=items_per_page,
         )
 
@@ -229,5 +229,5 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 total_items_count=total_items_count,
                 items_per_page=self._sanitised_query_limit(items_per_page),
                 cursor_reference=cursor_reference,
-                is_end_cursor=is_end_cursor,
+                is_before_cursor=is_before_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -65,11 +65,6 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             yield self._external_session
 
     async def save(self, instance: MODEL) -> MODEL:
-        """Persist a model.
-
-        :param instance: A mapped object instance to be persisted
-        :return: The model instance after being persisted
-        """
         async with self._get_session() as session:
             session.add(instance)
         return instance
@@ -78,24 +73,11 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         self,
         instances: Iterable[MODEL],
     ) -> Iterable[MODEL]:
-        """Persist many models in a single database get_session.
-
-        :param instances: A list of mapped objects to be persisted
-        :type instances: Iterable
-        :return: The model instances after being persisted
-        """
         async with self._get_session() as session:
             session.add_all(instances)
         return instances
 
     async def get(self, identifier: PRIMARY_KEY) -> MODEL:
-        """Get a model by primary key.
-
-        :param identifier: The primary key
-        :return: A model instance
-        :raises ModelNotFound: No model has been found using the primary key
-        """
-        # TODO: implement get_many()
         async with self._get_session(commit=False) as session:
             model = await session.get(self._model, identifier)
         if model is None:
@@ -106,11 +88,6 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         self,
         entity: Union[MODEL, PRIMARY_KEY],
     ) -> None:
-        """Deletes a model.
-
-        :param entity: The model instance or the primary key
-        :type entity: Union[MODEL, PRIMARY_KEY]
-        """
         # TODO: delete without loading the model
         if isinstance(entity, self._model):
             obj = entity
@@ -124,20 +101,6 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
     ) -> List[MODEL]:
-        """Find models using filters
-
-        E.g.
-        find(search_params={"name": "John"}) finds all models with name = John
-
-        :param order_by:
-        :param search_params: A dictionary containing equality filters
-        :param limit: Number of models to retrieve
-        :type limit: int
-        :param offset: Number of models to skip
-        :type offset: int
-        :return: A collection of models
-        :rtype: List
-        """
         stmt = self._find_query(search_params, order_by)
 
         async with self._get_session() as session:
@@ -147,25 +110,10 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     async def paginated_find(
         self,
         items_per_page: int,
-        page: int,
+        page: int = 1,
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
     ) -> PaginatedResult[MODEL]:
-        """Find models using filters and pagination
-
-        E.g.
-        find(name="John") finds all models with name = John
-
-        :param items_per_page: Number of models to retrieve
-        :type items_per_page: int
-        :param page: Page to retrieve
-        :type page: int
-        :param search_params: A dictionary containing equality filters
-        :param order_by:
-        :return: A collection of models
-        :rtype: List
-        """
-
         find_stmt = self._find_query(search_params, order_by)
         paginated_stmt = self._paginate_query_by_page(find_stmt, page, items_per_page)
 
@@ -191,23 +139,6 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
-        """Find models using filters and cursor based pagination
-
-        E.g.
-        find(name="John") finds all models with name = John
-
-        :param items_per_page: Number of models to retrieve
-        :type items_per_page: int
-        :param order_by: Model property to use for ordering and before/after evaluation
-        :type order_by: str
-        :param before: Identifier of the last node to skip
-        :type before: Union[int, str]
-        :param after: Identifier of the last node to skip
-        :type after: Union[int, str]
-        :param search_params: A dictionary containing equality filters
-        :return: A collection of models
-        :rtype: List
-        """
         find_stmt = self._find_query(search_params)
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -222,34 +222,31 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             result_items = [
                 x for x in (await session.execute(paginated_stmt)).scalars()
             ] or []
+
             sanitised_query_limit = self._calculate_sanitised_query_limit(
                 items_per_page
             )
 
+            reference_cursor = before or after
+            index = 0 if after else len(result_items) - 1
+            if (
+                result_items
+                and getattr(result_items[index], order_by) <= reference_cursor
+            ):
+                has_previous_page = True
+                result_items.pop(index)
+            else:
+                has_previous_page = False
+
             if len(result_items) > sanitised_query_limit:
                 has_next_page = True
-                result_items = result_items[0:sanitised_query_limit]
+                result_items = (
+                    result_items[0:sanitised_query_limit]
+                    if after
+                    else result_items[1 : sanitised_query_limit + 1]
+                )
             else:
                 has_next_page = False
-
-            previous_page_cursor_reference = (
-                getattr(result_items[0], order_by) if result_items else after or before
-            )
-            previous_page_stmt = self._cursor_paginated_query(
-                find_stmt,
-                order_column=order_by,
-                before=previous_page_cursor_reference if before is None else None,
-                after=previous_page_cursor_reference if after is None else None,
-                per_page=1,
-            )
-
-            has_previous_page = bool(
-                (await session.execute(self._count_query(previous_page_stmt))).scalar()
-                or 0
-            )
-
-            if before is not None:
-                result_items.reverse()
 
             return CursorPaginatedResult(
                 items=result_items,

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -213,7 +213,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             find_stmt,
             cursor_reference=cursor_reference,
             is_before_cursor=is_before_cursor,
-            per_page=items_per_page,
+            items_per_page=items_per_page,
         )
 
         async with self._get_session() as session:

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -135,7 +135,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
 
     async def paginated_find(
         self,
-        per_page: int,
+        items_per_page: int,
         page: int,
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
@@ -145,8 +145,8 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         E.g.
         find(name="John") finds all models with name = John
 
-        :param per_page: Number of models to retrieve
-        :type per_page: int
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
         :param page: Page to retrieve
         :type page: int
         :param search_params: A dictionary containing equality filters
@@ -156,7 +156,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         """
 
         find_stmt = self._find_query(search_params, order_by)
-        paginated_stmt = self._paginate_query_by_page(find_stmt, page, per_page)
+        paginated_stmt = self._paginate_query_by_page(find_stmt, page, items_per_page)
 
         async with self._get_session() as session:
             total_items_count = (
@@ -166,9 +166,47 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 x for x in (await session.execute(paginated_stmt)).scalars()
             ]
 
-            return self._build_paginated_by_page_result(
+            return self._build_paginated_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,
-                per_page=per_page,
+                items_per_page=items_per_page,
+            )
+
+    async def cursor_paginated_find(
+        self,
+        items_per_page: int,
+        after: Tuple[str, Union[int, str]],
+        search_params: Union[None, Mapping[str, Any]] = None,
+        direction: SortDirection = SortDirection.ASC,
+    ) -> PaginatedResult[MODEL]:
+        """Find models using filters and cursor based pagination
+
+        E.g.
+        find(name="John") finds all models with name = John
+
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
+        :param after: Identifier of the last node to skip, ("column_name", "value")
+        :type after: Tuple[str, Union[int, str]]
+        :param search_params: A dictionary containing equality filters
+        :param direction:
+        :return: A collection of models
+        :rtype: List
+        """
+
+        find_stmt = self._find_query(search_params)
+        paginated_stmt = self._paginate_query_by_cursor(find_stmt, after, items_per_page, direction)
+
+        async with self._get_session() as session:
+            total_items_count = (
+                    (await session.execute(self._count_query(find_stmt))).scalar() or 0
+            )
+            result_items = [x for x in (await session.execute(paginated_stmt)).scalars()]
+
+            return self._build_paginated_result(
+                result_items=result_items,
+                total_items_count=total_items_count,
+                page=None,
+                items_per_page=items_per_page,
             )

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -28,6 +28,7 @@ from .common import (
     CursorReference,
     PaginatedResult,
 )
+from .result_presenters import CursorPaginatedResultPresenter, PaginatedResultPresenter
 
 
 class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
@@ -176,11 +177,11 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 x for x in (await session.execute(paginated_stmt)).scalars()
             ]
 
-            return self._build_page_paginated_result(
+            return PaginatedResultPresenter.build_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,
-                items_per_page=items_per_page,
+                items_per_page=self._sanitised_query_limit(items_per_page),
             )
 
     async def cursor_paginated_find(
@@ -223,10 +224,10 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 x for x in (await session.execute(paginated_stmt)).scalars()
             ] or []
 
-            return self._build_cursor_paginated_result(
+            return CursorPaginatedResultPresenter.build_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
-                items_per_page=items_per_page,
+                items_per_page=self._sanitised_query_limit(items_per_page),
                 cursor_reference=cursor_reference,
                 is_end_cursor=is_end_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -223,35 +223,11 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 x for x in (await session.execute(paginated_stmt)).scalars()
             ] or []
 
-            sanitised_query_limit = self._calculate_sanitised_query_limit(
-                items_per_page
-            )
-
-            reference_cursor = before or after
-            index = 0 if after else len(result_items) - 1
-            if (
-                result_items
-                and getattr(result_items[index], order_by) <= reference_cursor
-            ):
-                has_previous_page = True
-                result_items.pop(index)
-            else:
-                has_previous_page = False
-
-            if len(result_items) > sanitised_query_limit:
-                has_next_page = True
-                result_items = (
-                    result_items[0:sanitised_query_limit]
-                    if after
-                    else result_items[1 : sanitised_query_limit + 1]
-                )
-            else:
-                has_next_page = False
-
-            return CursorPaginatedResult(
-                items=result_items,
-                items_per_page=sanitised_query_limit,
-                total_items=total_items_count,
-                has_next_page=has_next_page,
-                has_previous_page=has_previous_page,
+            return self._build_cursor_based_paginated_result(
+                result_items=result_items,
+                total_items_count=total_items_count,
+                items_per_page=items_per_page,
+                reference_cursor=before or after,
+                cursor_attribute=order_by,
+                is_end_cursor=before is not None,
             )

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -184,7 +184,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Cursor,
+        reference_cursor: Union[Cursor, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:

--- a/sqlalchemy_bind_manager/_repository/base_repository.py
+++ b/sqlalchemy_bind_manager/_repository/base_repository.py
@@ -148,7 +148,7 @@ class BaseRepository(Generic[MODEL], ABC):
         self,
         stmt: Select,
         page: int,
-        per_page: int,
+        items_per_page: int,
     ) -> Select:
         """Build the query offset and limit clauses from submitted parameters.
 
@@ -156,16 +156,16 @@ class BaseRepository(Generic[MODEL], ABC):
         :type stmt: Select
         :param page: Number of models to skip
         :type page: int
-        :param per_page: Number of models to retrieve
-        :type per_page: int
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
         :return: The filtered query
         """
 
-        _offset = max((page - 1) * per_page, 0)
+        _offset = max((page - 1) * items_per_page, 0)
         if _offset > 0:
             stmt = stmt.offset(_offset)
 
-        _limit = self._sanitised_query_limit(per_page)
+        _limit = self._sanitised_query_limit(items_per_page)
         stmt = stmt.limit(_limit)
 
         return stmt
@@ -175,7 +175,7 @@ class BaseRepository(Generic[MODEL], ABC):
         stmt: Select,
         cursor_reference: Union[CursorReference, None],
         is_before_cursor: bool = False,
-        per_page: int = _max_query_limit,
+        items_per_page: int = _max_query_limit,
     ) -> Select:
         """Build the query offset and limit clauses from submitted parameters.
 
@@ -185,12 +185,12 @@ class BaseRepository(Generic[MODEL], ABC):
         :type before: Union[int, str]
         :param after: Identifier of the last node to skip
         :type after: Union[int, str]
-        :param per_page: Number of models to retrieve
-        :type per_page: int
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
         :return: The filtered query
         """
 
-        forward_limit = self._sanitised_query_limit(per_page) + 1
+        forward_limit = self._sanitised_query_limit(items_per_page) + 1
 
         if not cursor_reference:
             return stmt.limit(forward_limit).order_by(  # type: ignore

--- a/sqlalchemy_bind_manager/_repository/base_repository.py
+++ b/sqlalchemy_bind_manager/_repository/base_repository.py
@@ -174,7 +174,7 @@ class BaseRepository(Generic[MODEL], ABC):
         self,
         stmt: Select,
         cursor_reference: Union[CursorReference, None],
-        is_end_cursor: bool = False,
+        is_before_cursor: bool = False,
         per_page: int = _max_query_limit,
     ) -> Select:
         """Build the query offset and limit clauses from submitted parameters.
@@ -198,7 +198,7 @@ class BaseRepository(Generic[MODEL], ABC):
             )
 
         # TODO: Use window functions
-        if not is_end_cursor:
+        if not is_before_cursor:
             previous_query = stmt.where(
                 getattr(self._model, cursor_reference.column) <= cursor_reference.value
             )

--- a/sqlalchemy_bind_manager/_repository/base_repository.py
+++ b/sqlalchemy_bind_manager/_repository/base_repository.py
@@ -1,13 +1,10 @@
 from abc import ABC
 from enum import Enum
 from functools import partial
-from math import ceil
 from typing import (
     Any,
-    Collection,
     Generic,
     Iterable,
-    List,
     Mapping,
     Tuple,
     Type,
@@ -23,11 +20,7 @@ from sqlalchemy_bind_manager.exceptions import InvalidModel, UnmappedProperty
 
 from .common import (
     MODEL,
-    CursorPageInfo,
-    CursorPaginatedResult,
     CursorReference,
-    PageInfo,
-    PaginatedResult,
 )
 
 
@@ -264,140 +257,6 @@ class BaseRepository(Generic[MODEL], ABC):
 
     def _sanitised_query_limit(self, limit):
         return max(min(limit, self._max_query_limit), 0)
-
-    def _build_page_paginated_result(
-        self,
-        result_items: Collection[MODEL],
-        total_items_count: int,
-        page: int,
-        items_per_page: int,
-    ) -> PaginatedResult:
-
-        _per_page = self._sanitised_query_limit(items_per_page)
-        total_pages = (
-            0
-            if total_items_count == 0 or total_items_count is None
-            else ceil(total_items_count / _per_page)
-        )
-
-        _page = 0 if len(result_items) == 0 else min(page, total_pages)
-        has_next_page = _page and _page < total_pages
-        has_previous_page = _page and _page > 1
-
-        return PaginatedResult(
-            items=result_items,
-            page_info=PageInfo(
-                page=_page,
-                items_per_page=_per_page,
-                total_items=total_items_count,
-                total_pages=total_pages,
-                has_next_page=has_next_page,
-                has_previous_page=has_previous_page,
-            ),
-        )
-
-    def _build_cursor_paginated_result(
-        self,
-        result_items: List[MODEL],
-        total_items_count: int,
-        items_per_page: int,
-        cursor_reference: Union[CursorReference, None],
-        is_end_cursor: bool,
-    ) -> CursorPaginatedResult:
-        """
-        Produces a structured paginated result identifying previous/next pages
-        and slicing results accordingly.
-
-        :param result_items:
-        :param total_items_count:
-        :param items_per_page:
-        :param cursor_reference:
-        :param is_end_cursor:
-        :return:
-        """
-
-        sanitised_query_limit = self._sanitised_query_limit(items_per_page)
-
-        result_structure: CursorPaginatedResult = CursorPaginatedResult(
-            items=result_items,
-            page_info=CursorPageInfo(
-                items_per_page=sanitised_query_limit,
-                total_items=total_items_count,
-            ),
-        )
-        if not result_items:
-            return result_structure
-
-        if not cursor_reference:
-            has_previous_page = False
-            has_next_page = len(result_items) > sanitised_query_limit
-            if has_next_page:
-                result_items = result_items[0:sanitised_query_limit]
-            # TODO: Infer default cursor format from model
-            result_structure.page_info.has_next_page = has_next_page
-            result_structure.page_info.has_previous_page = has_previous_page
-            reference_column = self._model_pk()
-
-        elif is_end_cursor:
-            index = -1
-            reference_column = cursor_reference.column
-            last_found_cursor_value = getattr(result_items[index], reference_column)
-            """
-            Currently we support only numeric or string model values for cursors,
-            but pydantic models (cursor) coerce always the value as string.
-            This mean if the value is not actually string we need to cast to
-            ensure correct ordering is evaluated.
-            e.g.
-            9 < 10 but '9' > '10' 
-            """
-            if isinstance(last_found_cursor_value, str):
-                has_next_page = last_found_cursor_value >= cursor_reference.value
-            else:
-                has_next_page = last_found_cursor_value >= float(cursor_reference.value)
-            if has_next_page:
-                result_items.pop(index)
-            has_previous_page = len(result_items) > sanitised_query_limit
-            if has_previous_page:
-                result_items = result_items[-sanitised_query_limit:]
-        else:
-            index = 0
-            reference_column = cursor_reference.column
-            first_found_cursor_value = getattr(result_items[index], reference_column)
-            """
-            Currently we support only numeric or string model values for cursors,
-            but pydantic models (cursor) coerce always the value as string.
-            This mean if the value is not actually string we need to cast to
-            ensure correct ordering is evaluated.
-            e.g.
-            9 < 10 but '9' > '10' 
-            """
-            if isinstance(first_found_cursor_value, str):
-                has_previous_page = first_found_cursor_value <= cursor_reference.value
-            else:
-                has_previous_page = first_found_cursor_value <= float(
-                    cursor_reference.value
-                )
-            if has_previous_page:
-                result_items.pop(index)
-            has_next_page = len(result_items) > sanitised_query_limit
-            if has_next_page:
-                result_items = result_items[0:sanitised_query_limit]
-
-        result_structure.items = result_items
-        result_structure.page_info.has_next_page = has_next_page
-        result_structure.page_info.has_previous_page = has_previous_page
-
-        if result_items:
-            result_structure.page_info.start_cursor = CursorReference(
-                column=reference_column,
-                value=getattr(result_items[0], reference_column),
-            )
-            result_structure.page_info.end_cursor = CursorReference(
-                column=reference_column,
-                value=getattr(result_items[-1], reference_column),
-            )
-
-        return result_structure
 
     def _model_pk(self) -> str:
         primary_keys = inspect(self._model).primary_key  # type: ignore

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -18,7 +18,7 @@ from typing import (
 
 from pydantic import BaseModel
 from pydantic.generics import GenericModel
-from sqlalchemy import asc, desc, func, select, inspect
+from sqlalchemy import asc, desc, func, inspect, select
 from sqlalchemy.orm import Mapper, aliased, class_mapper, lazyload
 from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.sql import Select
@@ -231,7 +231,9 @@ class BaseRepository(Generic[MODEL], ABC):
         forward_limit = self._sanitised_query_limit(per_page) + 1
 
         if not reference_cursor:
-            return stmt.limit(forward_limit).order_by(asc(self._model_pk()))  # type: ignore
+            return stmt.limit(forward_limit).order_by(  # type: ignore
+                asc(self._model_pk())
+            )
 
         # TODO: Use window functions
         if not is_end_cursor:

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -346,10 +346,14 @@ class BaseRepository(Generic[MODEL], ABC):
         if not result_items:
             return CursorPaginatedResult(
                 items=result_items,
-                items_per_page=sanitised_query_limit,
-                total_items=total_items_count,
-                has_next_page=False,
-                has_previous_page=False,
+                page_info=CursorPageInfo(
+                    items_per_page=sanitised_query_limit,
+                    total_items=total_items_count,
+                    has_next_page=False,
+                    has_previous_page=False,
+                    start_cursor=None,
+                    end_cursor=None,
+                ),
             )
 
         if is_end_cursor:

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -1,0 +1,40 @@
+from typing import Generic, List, TypeVar, Union
+
+from pydantic import BaseModel
+from pydantic.generics import GenericModel
+
+MODEL = TypeVar("MODEL")
+PRIMARY_KEY = Union[str, int, tuple, dict]
+
+
+class PageInfo(BaseModel):
+    page: int
+    items_per_page: int
+    total_pages: int
+    total_items: int
+    has_next_page: bool
+    has_previous_page: bool
+
+
+class PaginatedResult(GenericModel, Generic[MODEL]):
+    items: List[MODEL]
+    page_info: PageInfo
+
+
+class CursorPageInfo(BaseModel):
+    items_per_page: int
+    total_items: int
+    has_next_page: bool = False
+    has_previous_page: bool = False
+    start_cursor: Union[str, None] = None
+    end_cursor: Union[str, None] = None
+
+
+class CursorPaginatedResult(GenericModel, Generic[MODEL]):
+    items: List[MODEL]
+    page_info: CursorPageInfo
+
+
+class Cursor(BaseModel):
+    column: str
+    value: str

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -34,14 +34,18 @@ class SortDirection(Enum):
     DESC = partial(desc)
 
 
-class PaginatedResult(GenericModel, Generic[MODEL]):
-    items: List[MODEL]
+class PageInfo(BaseModel):
     page: int
     items_per_page: int
     total_pages: int
     total_items: int
     has_next_page: bool
     has_previous_page: bool
+
+
+class PaginatedResult(GenericModel, Generic[MODEL]):
+    items: List[MODEL]
+    page_info: PageInfo
 
 
 class CursorPageInfo(BaseModel):
@@ -308,12 +312,14 @@ class BaseRepository(Generic[MODEL], ABC):
 
         return PaginatedResult(
             items=result_items,
-            page=_page,
-            items_per_page=_per_page,
-            total_items=total_items_count,
-            total_pages=total_pages,
-            has_next_page=has_next_page,
-            has_previous_page=has_previous_page,
+            page_info=PageInfo(
+                page=_page,
+                items_per_page=_per_page,
+                total_items=total_items_count,
+                total_pages=total_pages,
+                has_next_page=has_next_page,
+                has_previous_page=has_previous_page,
+            ),
         )
 
     def _build_cursor_paginated_result(

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -1,6 +1,6 @@
 from typing import Generic, List, TypeVar, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic.generics import GenericModel
 
 MODEL = TypeVar("MODEL")
@@ -23,7 +23,7 @@ class PaginatedResult(GenericModel, Generic[MODEL]):
 
 class CursorReference(BaseModel):
     column: str
-    value: str
+    value: Union[StrictStr, StrictInt]
 
 
 class CursorPageInfo(BaseModel):

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -155,7 +155,7 @@ class BaseRepository(Generic[MODEL], ABC):
             query.options(lazyload("*")).order_by(None).subquery()  # type: ignore
         )
 
-    def _paginate_query(
+    def _paginate_query_by_page(
         self,
         stmt: Select,
         page: int,
@@ -181,7 +181,7 @@ class BaseRepository(Generic[MODEL], ABC):
 
         return stmt
 
-    def _build_paginated_result(
+    def _build_paginated_by_page_result(
         self,
         result_items: Collection[MODEL],
         total_items_count: int,

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -21,20 +21,20 @@ class PaginatedResult(GenericModel, Generic[MODEL]):
     page_info: PageInfo
 
 
+class CursorReference(BaseModel):
+    column: str
+    value: str
+
+
 class CursorPageInfo(BaseModel):
     items_per_page: int
     total_items: int
     has_next_page: bool = False
     has_previous_page: bool = False
-    start_cursor: Union[str, None] = None
-    end_cursor: Union[str, None] = None
+    start_cursor: Union[CursorReference, None] = None
+    end_cursor: Union[CursorReference, None] = None
 
 
 class CursorPaginatedResult(GenericModel, Generic[MODEL]):
     items: List[MODEL]
     page_info: CursorPageInfo
-
-
-class Cursor(BaseModel):
-    column: str
-    value: str

--- a/sqlalchemy_bind_manager/_repository/result_presenters.py
+++ b/sqlalchemy_bind_manager/_repository/result_presenters.py
@@ -1,0 +1,154 @@
+from math import ceil
+from typing import Collection, List, Union
+
+from sqlalchemy import inspect
+
+from .common import (
+    MODEL,
+    CursorPageInfo,
+    CursorPaginatedResult,
+    CursorReference,
+    PageInfo,
+    PaginatedResult,
+)
+
+
+class CursorPaginatedResultPresenter:
+    @staticmethod
+    def build_result(
+        result_items: List[MODEL],
+        total_items_count: int,
+        items_per_page: int,
+        cursor_reference: Union[CursorReference, None],
+        is_end_cursor: bool,
+    ) -> CursorPaginatedResult:
+        """
+        Produces a structured paginated result identifying previous/next pages
+        and slicing results accordingly.
+
+        :param result_items:
+        :param total_items_count:
+        :param items_per_page:
+        :param cursor_reference:
+        :param is_end_cursor:
+        :return:
+        """
+        result_structure: CursorPaginatedResult = CursorPaginatedResult(
+            items=result_items,
+            page_info=CursorPageInfo(
+                items_per_page=items_per_page,
+                total_items=total_items_count,
+            ),
+        )
+        if not result_items:
+            return result_structure
+
+        if not cursor_reference:
+            has_previous_page = False
+            has_next_page = len(result_items) > items_per_page
+            if has_next_page:
+                result_items = result_items[0:items_per_page]
+            result_structure.page_info.has_next_page = has_next_page
+            result_structure.page_info.has_previous_page = has_previous_page
+            reference_column = _pk_from_result_object(result_items[0])
+
+        elif is_end_cursor:
+            index = -1
+            reference_column = cursor_reference.column
+            last_found_cursor_value = getattr(result_items[index], reference_column)
+            """
+            Currently we support only numeric or string model values for cursors,
+            but pydantic models (cursor) coerce always the value as string.
+            This mean if the value is not actually string we need to cast to
+            ensure correct ordering is evaluated.
+            e.g.
+            9 < 10 but '9' > '10' 
+            """
+            if isinstance(last_found_cursor_value, str):
+                has_next_page = last_found_cursor_value >= cursor_reference.value
+            else:
+                has_next_page = last_found_cursor_value >= float(cursor_reference.value)
+            if has_next_page:
+                result_items.pop(index)
+            has_previous_page = len(result_items) > items_per_page
+            if has_previous_page:
+                result_items = result_items[-items_per_page:]
+        else:
+            index = 0
+            reference_column = cursor_reference.column
+            first_found_cursor_value = getattr(result_items[index], reference_column)
+            """
+            Currently we support only numeric or string model values for cursors,
+            but pydantic models (cursor) coerce always the value as string.
+            This mean if the value is not actually string we need to cast to
+            ensure correct ordering is evaluated.
+            e.g.
+            9 < 10 but '9' > '10' 
+            """
+            if isinstance(first_found_cursor_value, str):
+                has_previous_page = first_found_cursor_value <= cursor_reference.value
+            else:
+                has_previous_page = first_found_cursor_value <= float(
+                    cursor_reference.value
+                )
+            if has_previous_page:
+                result_items.pop(index)
+            has_next_page = len(result_items) > items_per_page
+            if has_next_page:
+                result_items = result_items[0:items_per_page]
+
+        result_structure.items = result_items
+        result_structure.page_info.has_next_page = has_next_page
+        result_structure.page_info.has_previous_page = has_previous_page
+
+        if result_items:
+            result_structure.page_info.start_cursor = CursorReference(
+                column=reference_column,
+                value=getattr(result_items[0], reference_column),
+            )
+            result_structure.page_info.end_cursor = CursorReference(
+                column=reference_column,
+                value=getattr(result_items[-1], reference_column),
+            )
+
+        return result_structure
+
+
+class PaginatedResultPresenter:
+    @staticmethod
+    def build_result(
+        result_items: Collection[MODEL],
+        total_items_count: int,
+        page: int,
+        items_per_page: int,
+    ) -> PaginatedResult:
+
+        total_pages = (
+            0
+            if total_items_count == 0 or total_items_count is None
+            else ceil(total_items_count / items_per_page)
+        )
+
+        _page = 0 if len(result_items) == 0 else min(page, total_pages)
+        has_next_page = _page and _page < total_pages
+        has_previous_page = _page and _page > 1
+
+        return PaginatedResult(
+            items=result_items,
+            page_info=PageInfo(
+                page=_page,
+                items_per_page=items_per_page,
+                total_items=total_items_count,
+                total_pages=total_pages,
+                has_next_page=has_next_page,
+                has_previous_page=has_previous_page,
+            ),
+        )
+
+
+def _pk_from_result_object(model) -> str:
+    primary_keys = inspect(type(model)).primary_key  # type: ignore
+    if len(primary_keys) > 1:
+        raise NotImplementedError("Composite primary keys are not supported.")
+
+    return primary_keys[0].name

--- a/sqlalchemy_bind_manager/_repository/result_presenters.py
+++ b/sqlalchemy_bind_manager/_repository/result_presenters.py
@@ -14,13 +14,14 @@ from .common import (
 
 
 class CursorPaginatedResultPresenter:
-    @staticmethod
+    @classmethod
     def build_result(
+        cls,
         result_items: List[MODEL],
         total_items_count: int,
         items_per_page: int,
         cursor_reference: Union[CursorReference, None],
-        is_end_cursor: bool,
+        is_before_cursor: bool,
     ) -> CursorPaginatedResult:
         """
         Produces a structured paginated result identifying previous/next pages
@@ -30,72 +31,153 @@ class CursorPaginatedResultPresenter:
         :param total_items_count:
         :param items_per_page:
         :param cursor_reference:
-        :param is_end_cursor:
+        :param is_before_cursor:
         :return:
         """
-        result_structure: CursorPaginatedResult = CursorPaginatedResult(
-            items=result_items,
+        if not result_items:
+            return cls._build_empty_items_result(total_items_count, items_per_page)
+
+        if not cursor_reference:
+            return cls._build_no_cursor_result(
+                result_items, total_items_count, items_per_page
+            )
+
+        if is_before_cursor:
+            return cls._build_before_cursor_result(
+                result_items, total_items_count, items_per_page, cursor_reference
+            )
+
+        return cls._build_after_cursor_result(
+            result_items, total_items_count, items_per_page, cursor_reference
+        )
+
+    @staticmethod
+    def _build_empty_items_result(
+        total_items_count: int,
+        items_per_page: int,
+    ) -> CursorPaginatedResult:
+        return CursorPaginatedResult(
+            items=[],
             page_info=CursorPageInfo(
                 items_per_page=items_per_page,
                 total_items=total_items_count,
             ),
         )
-        if not result_items:
-            return result_structure
 
-        if not cursor_reference:
-            has_previous_page = False
-            has_next_page = len(result_items) > items_per_page
-            if has_next_page:
-                result_items = result_items[0:items_per_page]
-            result_structure.page_info.has_next_page = has_next_page
-            result_structure.page_info.has_previous_page = has_previous_page
-            reference_column = _pk_from_result_object(result_items[0])
+    @staticmethod
+    def _build_no_cursor_result(
+        result_items: List[MODEL],
+        total_items_count: int,
+        items_per_page: int,
+    ) -> CursorPaginatedResult:
+        has_next_page = len(result_items) > items_per_page
+        if has_next_page:
+            result_items = result_items[0:items_per_page]
+        reference_column = _pk_from_result_object(result_items[0])
 
-        elif is_end_cursor:
-            index = -1
-            reference_column = cursor_reference.column
-            last_found_cursor_value = getattr(result_items[index], reference_column)
-            if not isinstance(last_found_cursor_value, type(cursor_reference.value)):
-                raise TypeError(
-                    "Values from CursorReference and results must be of the same type"
-                )
-            has_next_page = last_found_cursor_value >= cursor_reference.value
-            if has_next_page:
-                result_items.pop(index)
-            has_previous_page = len(result_items) > items_per_page
-            if has_previous_page:
-                result_items = result_items[-items_per_page:]
-        else:
-            index = 0
-            reference_column = cursor_reference.column
-            first_found_cursor_value = getattr(result_items[index], reference_column)
-            if not isinstance(first_found_cursor_value, type(cursor_reference.value)):
-                raise TypeError(
-                    "Values from CursorReference and results must be of the same type"
-                )
-            has_previous_page = first_found_cursor_value <= cursor_reference.value
-            if has_previous_page:
-                result_items.pop(index)
-            has_next_page = len(result_items) > items_per_page
-            if has_next_page:
-                result_items = result_items[0:items_per_page]
+        return CursorPaginatedResult(
+            items=result_items,
+            page_info=CursorPageInfo(
+                items_per_page=items_per_page,
+                total_items=total_items_count,
+                has_previous_page=False,
+                has_next_page=has_next_page,
+                start_cursor=CursorReference(
+                    column=reference_column,
+                    value=getattr(result_items[0], reference_column),
+                ),
+                end_cursor=CursorReference(
+                    column=reference_column,
+                    value=getattr(result_items[-1], reference_column),
+                ),
+            ),
+        )
 
-        result_structure.items = result_items
-        result_structure.page_info.has_next_page = has_next_page
-        result_structure.page_info.has_previous_page = has_previous_page
-
-        if result_items:
-            result_structure.page_info.start_cursor = CursorReference(
-                column=reference_column,
-                value=getattr(result_items[0], reference_column),
+    @staticmethod
+    def _build_before_cursor_result(
+        result_items: List[MODEL],
+        total_items_count: int,
+        items_per_page: int,
+        cursor_reference: CursorReference,
+    ) -> CursorPaginatedResult:
+        index = -1
+        reference_column = cursor_reference.column
+        last_found_cursor_value = getattr(result_items[index], reference_column)
+        if not isinstance(last_found_cursor_value, type(cursor_reference.value)):
+            raise TypeError(
+                "Values from CursorReference and results must be of the same type"
             )
-            result_structure.page_info.end_cursor = CursorReference(
-                column=reference_column,
-                value=getattr(result_items[-1], reference_column),
-            )
+        has_next_page = last_found_cursor_value >= cursor_reference.value
+        if has_next_page:
+            result_items.pop(index)
+        has_previous_page = len(result_items) > items_per_page
+        if has_previous_page:
+            result_items = result_items[-items_per_page:]
 
-        return result_structure
+        return CursorPaginatedResult(
+            items=result_items,
+            page_info=CursorPageInfo(
+                items_per_page=items_per_page,
+                total_items=total_items_count,
+                has_previous_page=has_previous_page,
+                has_next_page=has_next_page,
+                start_cursor=CursorReference(
+                    column=reference_column,
+                    value=getattr(result_items[0], reference_column),
+                )
+                if result_items
+                else None,
+                end_cursor=CursorReference(
+                    column=reference_column,
+                    value=getattr(result_items[-1], reference_column),
+                )
+                if result_items
+                else None,
+            ),
+        )
+
+    @staticmethod
+    def _build_after_cursor_result(
+        result_items: List[MODEL],
+        total_items_count: int,
+        items_per_page: int,
+        cursor_reference: CursorReference,
+    ) -> CursorPaginatedResult:
+        index = 0
+        reference_column = cursor_reference.column
+        first_found_cursor_value = getattr(result_items[index], reference_column)
+        if not isinstance(first_found_cursor_value, type(cursor_reference.value)):
+            raise TypeError(
+                "Values from CursorReference and results must be of the same type"
+            )
+        has_previous_page = first_found_cursor_value <= cursor_reference.value
+        if has_previous_page:
+            result_items.pop(index)
+        has_next_page = len(result_items) > items_per_page
+        if has_next_page:
+            result_items = result_items[0:items_per_page]
+
+        return CursorPaginatedResult(
+            items=result_items,
+            page_info=CursorPageInfo(
+                items_per_page=items_per_page,
+                total_items=total_items_count,
+                has_previous_page=has_previous_page,
+                has_next_page=has_next_page,
+                start_cursor=CursorReference(
+                    column=reference_column,
+                    value=getattr(result_items[0], reference_column),
+                )
+                if result_items
+                else None,
+                end_cursor=CursorReference(
+                    column=reference_column,
+                    value=getattr(result_items[-1], reference_column),
+                )
+                if result_items
+                else None,
+            ),
+        )
 
 
 class PaginatedResultPresenter:

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -146,7 +146,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         """
 
         find_stmt = self._find_query(search_params, order_by)
-        paginated_stmt = self._paginate_query(find_stmt, page, per_page)
+        paginated_stmt = self._paginate_query_by_page(find_stmt, page, per_page)
 
         with self._get_session() as session:
             total_items_count = (
@@ -154,7 +154,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
 
-            return self._build_paginated_result(
+            return self._build_paginated_by_page_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -176,7 +176,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         self,
         items_per_page: int,
         cursor_reference: Union[CursorReference, None] = None,
-        is_end_cursor: bool = False,
+        is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         """Find models using filters and cursor based pagination
@@ -201,7 +201,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,
             cursor_reference=cursor_reference,
-            is_end_cursor=is_end_cursor,
+            is_before_cursor=is_before_cursor,
             per_page=items_per_page,
         )
 
@@ -216,5 +216,5 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 total_items_count=total_items_count,
                 items_per_page=self._sanitised_query_limit(items_per_page),
                 cursor_reference=cursor_reference,
-                is_end_cursor=is_end_cursor,
+                is_before_cursor=is_before_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -21,6 +21,7 @@ from .common import (
     MODEL,
     PRIMARY_KEY,
     BaseRepository,
+    Cursor,
     CursorPaginatedResult,
     PaginatedResult,
     SortDirection,
@@ -161,7 +162,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
 
-            return self._build_page_based_paginated_result(
+            return self._build_page_paginated_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,
@@ -171,9 +172,8 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        order_by: str,
-        before: Union[int, str, None] = None,
-        after: Union[int, str, None] = None,
+        reference_cursor: Cursor,
+        is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         """Find models using filters and cursor based pagination
@@ -193,13 +193,12 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :return: A collection of models
         :rtype: List
         """
-
         find_stmt = self._find_query(search_params)
+
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,
-            order_column=order_by,
-            before=before,
-            after=after,
+            reference_cursor=reference_cursor,
+            is_end_cursor=is_end_cursor,
             per_page=items_per_page,
         )
 
@@ -209,11 +208,10 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
 
-            return self._build_cursor_based_paginated_result(
+            return self._build_cursor_paginated_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 items_per_page=items_per_page,
-                reference_cursor=before or after,
-                cursor_attribute=order_by,
-                is_end_cursor=before is not None,
+                reference_cursor=reference_cursor,
+                is_end_cursor=is_end_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -21,7 +21,13 @@ from .base_repository import (
     BaseRepository,
     SortDirection,
 )
-from .common import MODEL, PRIMARY_KEY, Cursor, CursorPaginatedResult, PaginatedResult
+from .common import (
+    MODEL,
+    PRIMARY_KEY,
+    CursorPaginatedResult,
+    CursorReference,
+    PaginatedResult,
+)
 
 
 class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
@@ -168,7 +174,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, str, None] = None,
+        cursor_reference: Union[CursorReference, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -189,14 +195,11 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :return: A collection of models
         :rtype: List
         """
-        if isinstance(reference_cursor, str):
-            reference_cursor = self.decode_cursor(reference_cursor)
-
         find_stmt = self._find_query(search_params)
 
         paginated_stmt = self._cursor_paginated_query(
             find_stmt,
-            reference_cursor=reference_cursor,
+            cursor_reference=cursor_reference,
             is_end_cursor=is_end_cursor,
             per_page=items_per_page,
         )
@@ -211,6 +214,6 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
                 result_items=result_items,
                 total_items_count=total_items_count,
                 items_per_page=items_per_page,
-                reference_cursor=reference_cursor,
+                cursor_reference=cursor_reference,
                 is_end_cursor=is_end_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -172,7 +172,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Cursor,
+        reference_cursor: Union[Cursor, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -18,14 +18,10 @@ from .._bind_manager import SQLAlchemyBind
 from .._transaction_handler import SessionHandler
 from ..exceptions import InvalidConfig, ModelNotFound
 from .base_repository import (
-    MODEL,
-    PRIMARY_KEY,
     BaseRepository,
-    Cursor,
-    CursorPaginatedResult,
-    PaginatedResult,
     SortDirection,
 )
+from .common import MODEL, PRIMARY_KEY, Cursor, CursorPaginatedResult, PaginatedResult
 
 
 class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -172,7 +172,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, None] = None,
+        reference_cursor: Union[Cursor, str, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -193,6 +193,9 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         :return: A collection of models
         :rtype: List
         """
+        if isinstance(reference_cursor, str):
+            reference_cursor = self.decode_cursor(reference_cursor)
+
         find_stmt = self._find_query(search_params)
 
         paginated_stmt = self._cursor_paginated_query(

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 from .._bind_manager import SQLAlchemyBind
 from .._transaction_handler import SessionHandler
 from ..exceptions import InvalidConfig, ModelNotFound
-from .common import (
+from .base_repository import (
     MODEL,
     PRIMARY_KEY,
     BaseRepository,

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -28,6 +28,7 @@ from .common import (
     CursorReference,
     PaginatedResult,
 )
+from .result_presenters import CursorPaginatedResultPresenter, PaginatedResultPresenter
 
 
 class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
@@ -164,11 +165,11 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
 
-            return self._build_page_paginated_result(
+            return PaginatedResultPresenter.build_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,
-                items_per_page=items_per_page,
+                items_per_page=self._sanitised_query_limit(items_per_page),
             )
 
     def cursor_paginated_find(
@@ -210,10 +211,10 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
 
-            return self._build_cursor_paginated_result(
+            return CursorPaginatedResultPresenter.build_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
-                items_per_page=items_per_page,
+                items_per_page=self._sanitised_query_limit(items_per_page),
                 cursor_reference=cursor_reference,
                 is_end_cursor=is_end_cursor,
             )

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -17,7 +17,14 @@ from sqlalchemy.orm import Session
 from .._bind_manager import SQLAlchemyBind
 from .._transaction_handler import SessionHandler
 from ..exceptions import InvalidConfig, ModelNotFound
-from .common import MODEL, PRIMARY_KEY, BaseRepository, PaginatedResult, SortDirection
+from .common import (
+    MODEL,
+    PRIMARY_KEY,
+    BaseRepository,
+    CursorPaginatedResult,
+    PaginatedResult,
+    SortDirection,
+)
 
 
 class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
@@ -154,7 +161,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
 
-            return self._build_paginated_result(
+            return self._build_page_based_paginated_result(
                 result_items=result_items,
                 total_items_count=total_items_count,
                 page=page,
@@ -164,10 +171,11 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        after: Tuple[str, Union[int, str]],
+        order_by: str,
+        before: Union[int, str, None] = None,
+        after: Union[int, str, None] = None,
         search_params: Union[None, Mapping[str, Any]] = None,
-        direction: SortDirection = SortDirection.ASC,
-    ) -> PaginatedResult[MODEL]:
+    ) -> CursorPaginatedResult[MODEL]:
         """Find models using filters and cursor based pagination
 
         E.g.
@@ -175,26 +183,63 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
 
         :param items_per_page: Number of models to retrieve
         :type items_per_page: int
-        :param after: Identifier of the last node to skip, ("column_name", "value")
-        :type after: Tuple[str, Union[int, str]]
+        :param order_by: Model property to use for ordering and before/after evaluation
+        :type order_by: str
+        :param before: Identifier of the last node to skip
+        :type before: Union[int, str]
+        :param after: Identifier of the last node to skip
+        :type after: Union[int, str]
         :param search_params: A dictionary containing equality filters
-        :param direction:
         :return: A collection of models
         :rtype: List
         """
 
         find_stmt = self._find_query(search_params)
-        paginated_stmt = self._paginate_query_by_cursor(find_stmt, after, items_per_page, direction)
+        paginated_stmt = self._cursor_paginated_query(
+            find_stmt,
+            order_column=order_by,
+            before=before,
+            after=after,
+            per_page=items_per_page,
+        )
 
         with self._get_session() as session:
             total_items_count = (
                 session.execute(self._count_query(find_stmt)).scalar() or 0
             )
             result_items = [x for x in session.execute(paginated_stmt).scalars()]
+            sanitised_query_limit = self._calculate_sanitised_query_limit(
+                items_per_page
+            )
 
-            return self._build_paginated_result(
-                result_items=result_items,
-                total_items_count=total_items_count,
-                page=None,
-                items_per_page=items_per_page,
+            if len(result_items) > sanitised_query_limit:
+                has_next_page = True
+                result_items = result_items[0:sanitised_query_limit]
+            else:
+                has_next_page = False
+
+            previous_page_cursor_reference = (
+                getattr(result_items[0], order_by) if result_items else after or before
+            )
+            previous_page_stmt = self._cursor_paginated_query(
+                find_stmt,
+                order_column=order_by,
+                before=previous_page_cursor_reference if before is None else None,
+                after=previous_page_cursor_reference if after is None else None,
+                per_page=1,
+            )
+
+            has_previous_page = bool(
+                session.execute(self._count_query(previous_page_stmt)).scalar() or 0
+            )
+
+            if before is not None:
+                result_items.reverse()
+
+            return CursorPaginatedResult(
+                items=result_items,
+                items_per_page=sanitised_query_limit,
+                total_items=total_items_count,
+                has_next_page=has_next_page,
+                has_previous_page=has_previous_page,
             )

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -202,7 +202,7 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             find_stmt,
             cursor_reference=cursor_reference,
             is_before_cursor=is_before_cursor,
-            per_page=items_per_page,
+            items_per_page=items_per_page,
         )
 
         with self._get_session() as session:

--- a/sqlalchemy_bind_manager/_unit_of_work.py
+++ b/sqlalchemy_bind_manager/_unit_of_work.py
@@ -4,11 +4,14 @@ from typing import AsyncIterator, Iterable, Iterator, Type
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from sqlalchemy_bind_manager import SQLAlchemyAsyncRepository, SQLAlchemyRepository
 from sqlalchemy_bind_manager._bind_manager import SQLAlchemyAsyncBind, SQLAlchemyBind
 from sqlalchemy_bind_manager._transaction_handler import (
     AsyncSessionHandler,
     SessionHandler,
+)
+from sqlalchemy_bind_manager.repository import (
+    SQLAlchemyAsyncRepository,
+    SQLAlchemyRepository,
 )
 
 

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -52,7 +52,7 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, None] = None,
+        reference_cursor: Union[Cursor, str, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -92,7 +92,7 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, None] = None,
+        reference_cursor: Union[Cursor, str, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -9,9 +9,11 @@ from typing import (
     runtime_checkable,
 )
 
-from sqlalchemy_bind_manager._repository.base_repository import (
+from sqlalchemy_bind_manager._repository.common import (
     MODEL,
     PRIMARY_KEY,
+)
+from sqlalchemy_bind_manager.repository import (
     Cursor,
     CursorPaginatedResult,
     PaginatedResult,

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -9,7 +9,7 @@ from typing import (
     runtime_checkable,
 )
 
-from sqlalchemy_bind_manager._repository.common import (
+from sqlalchemy_bind_manager._repository.base_repository import (
     MODEL,
     PRIMARY_KEY,
     Cursor,

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -12,6 +12,7 @@ from typing import (
 from sqlalchemy_bind_manager._repository.common import (
     MODEL,
     PRIMARY_KEY,
+    Cursor,
     CursorPaginatedResult,
     PaginatedResult,
     SortDirection,
@@ -51,9 +52,8 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        order_by: str,
-        before: Union[int, str, None] = None,
-        after: Union[int, str, None] = None,
+        reference_cursor: Cursor,
+        is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         ...
@@ -92,9 +92,8 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        order_by: str,
-        before: Union[int, str, None] = None,
-        after: Union[int, str, None] = None,
+        reference_cursor: Cursor,
+        is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         ...

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -52,7 +52,7 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Cursor,
+        reference_cursor: Union[Cursor, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -92,7 +92,7 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Cursor,
+        reference_cursor: Union[Cursor, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -40,10 +40,19 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
 
     async def paginated_find(
         self,
-        per_page: int,
+        items_per_page: int,
         page: int,
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
+    ) -> PaginatedResult[MODEL]:
+        ...
+
+    async def cursor_paginated_find(
+        self,
+        items_per_page: int,
+        after: Tuple[str, Union[int, str]],
+        search_params: Union[None, Mapping[str, Any]] = None,
+        direction: SortDirection = SortDirection.ASC,
     ) -> PaginatedResult[MODEL]:
         ...
 
@@ -71,9 +80,18 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
 
     def paginated_find(
         self,
-        per_page: int,
+        items_per_page: int,
         page: int,
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
+    ) -> PaginatedResult[MODEL]:
+        ...
+
+    def cursor_paginated_find(
+        self,
+        items_per_page: int,
+        after: Tuple[str, Union[int, str]],
+        search_params: Union[None, Mapping[str, Any]] = None,
+        direction: SortDirection = SortDirection.ASC,
     ) -> PaginatedResult[MODEL]:
         ...

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -55,7 +55,7 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
         self,
         items_per_page: int,
         cursor_reference: Union[CursorReference, None] = None,
-        is_end_cursor: bool = False,
+        is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         ...
@@ -95,7 +95,7 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
         self,
         items_per_page: int,
         cursor_reference: Union[CursorReference, None] = None,
-        is_end_cursor: bool = False,
+        is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
         ...

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -14,8 +14,8 @@ from sqlalchemy_bind_manager._repository.common import (
     PRIMARY_KEY,
 )
 from sqlalchemy_bind_manager.repository import (
-    Cursor,
     CursorPaginatedResult,
+    CursorReference,
     PaginatedResult,
     SortDirection,
 )
@@ -54,7 +54,7 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, str, None] = None,
+        cursor_reference: Union[CursorReference, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
@@ -94,7 +94,7 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        reference_cursor: Union[Cursor, str, None] = None,
+        cursor_reference: Union[CursorReference, None] = None,
         is_end_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -12,6 +12,7 @@ from typing import (
 from sqlalchemy_bind_manager._repository.common import (
     MODEL,
     PRIMARY_KEY,
+    CursorPaginatedResult,
     PaginatedResult,
     SortDirection,
 )
@@ -50,10 +51,11 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def cursor_paginated_find(
         self,
         items_per_page: int,
-        after: Tuple[str, Union[int, str]],
+        order_by: str,
+        before: Union[int, str, None] = None,
+        after: Union[int, str, None] = None,
         search_params: Union[None, Mapping[str, Any]] = None,
-        direction: SortDirection = SortDirection.ASC,
-    ) -> PaginatedResult[MODEL]:
+    ) -> CursorPaginatedResult[MODEL]:
         ...
 
 
@@ -90,8 +92,9 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def cursor_paginated_find(
         self,
         items_per_page: int,
-        after: Tuple[str, Union[int, str]],
+        order_by: str,
+        before: Union[int, str, None] = None,
+        after: Union[int, str, None] = None,
         search_params: Union[None, Mapping[str, Any]] = None,
-        direction: SortDirection = SortDirection.ASC,
-    ) -> PaginatedResult[MODEL]:
+    ) -> CursorPaginatedResult[MODEL]:
         ...

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -24,15 +24,38 @@ from sqlalchemy_bind_manager.repository import (
 @runtime_checkable
 class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def save(self, instance: MODEL) -> MODEL:
+        """Persist a model.
+
+        :param instance: A mapped object instance to be persisted
+        :return: The model instance after being persisted
+        """
         ...
 
     async def save_many(self, instances: Iterable[MODEL]) -> Iterable[MODEL]:
+        """Persist many models in a single database get_session.
+
+        :param instances: A list of mapped objects to be persisted
+        :type instances: Iterable
+        :return: The model instances after being persisted
+        """
         ...
 
     async def get(self, identifier: PRIMARY_KEY) -> MODEL:
+        """Get a model by primary key.
+
+        :param identifier: The primary key
+        :return: A model instance
+        :raises ModelNotFound: No model has been found using the primary key
+        """
+        # TODO: implement get_many()
         ...
 
     async def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:
+        """Deletes a model.
+
+        :param entity: The model instance or the primary key
+        :type entity: Union[MODEL, PRIMARY_KEY]
+        """
         ...
 
     async def find(
@@ -40,15 +63,64 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
     ) -> List[MODEL]:
+        """Find models using filters.
+
+        E.g.
+        find(search_params={"name":"John"})
+            finds all models with name = John
+
+        find(order_by=["name"])
+            finds all models ordered by `name` column
+
+        find(order_by=[("name", SortDirection.DESC)])
+            finds all models with reversed order by `name` column
+
+        :param search_params: A mapping containing equality filters
+        :type search_params: Mapping
+        :param order_by:
+        :type order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]]
+        :return: A collection of models
+        :rtype: List
+        """
         ...
 
     async def paginated_find(
         self,
         items_per_page: int,
-        page: int,
+        page: int = 1,
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
     ) -> PaginatedResult[MODEL]:
+        """Find models using filters and limit/offset pagination. Returned results
+        do include pagination metadata.
+
+        E.g.
+        paginated_find(search_params={"name":"John"})
+            finds all models with name = John
+
+        paginated_find(50, search_params={"name":"John"})
+            finds first 50 models with name = John
+
+        paginated_find(50, 3, search_params={"name":"John"})
+            finds 50 models with name = John, skipping 2 pages (100)
+
+        paginated_find(order_by=["name"])
+            finds all models ordered by `name` column
+
+        paginated_find(order_by=[("name", SortDirection.DESC)])
+            finds all models with reversed order by `name` column
+
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
+        :param page: Page to retrieve
+        :type page: int
+        :param search_params: A mapping containing equality filters
+        :type search_params: Mapping
+        :param order_by:
+        :type order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]]
+        :return: A collection of models
+        :rtype: List
+        """
         ...
 
     async def cursor_paginated_find(
@@ -58,21 +130,73 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
         is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
+        """Find models using filters and cursor based pagination. Returned results
+        do include pagination metadata.
+
+        E.g.
+        cursor_paginated_find(search_params={"name":"John"})
+            finds all models with name = John
+
+        cursor_paginated_find(50, search_params={"name":"John"})
+            finds first 50 models with name = John
+
+        cursor_paginated_find(50, CursorReference(column="id", value=123))
+            finds first 50 models after the one with "id" 123
+
+        cursor_paginated_find(50, CursorReference(column="id", value=123), True)
+            finds last 50 models before the one with "id" 123
+
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
+        :param cursor_reference: A cursor reference containing ordering column
+            and threshold value
+        :type cursor_reference: Union[CursorReference, None]
+        :param is_before_cursor: If True it will return items before the cursor,
+            otherwise items after
+        :type is_before_cursor: bool
+        :param search_params: A mapping containing equality filters
+        :type search_params: Mapping
+        :return: A collection of models
+        :rtype: List
+        """
         ...
 
 
 @runtime_checkable
 class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def save(self, instance: MODEL) -> MODEL:
+        """Persist a model.
+
+        :param instance: A mapped object instance to be persisted
+        :return: The model instance after being persisted
+        """
         ...
 
     def save_many(self, instances: Iterable[MODEL]) -> Iterable[MODEL]:
+        """Persist many models in a single database get_session.
+
+        :param instances: A list of mapped objects to be persisted
+        :type instances: Iterable
+        :return: The model instances after being persisted
+        """
         ...
 
     def get(self, identifier: PRIMARY_KEY) -> MODEL:
+        """Get a model by primary key.
+
+        :param identifier: The primary key
+        :return: A model instance
+        :raises ModelNotFound: No model has been found using the primary key
+        """
+        # TODO: implement get_many()
         ...
 
     def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:
+        """Deletes a model.
+
+        :param entity: The model instance or the primary key
+        :type entity: Union[MODEL, PRIMARY_KEY]
+        """
         ...
 
     def find(
@@ -80,15 +204,64 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
     ) -> List[MODEL]:
+        """Find models using filters.
+
+        E.g.
+        find(search_params={"name":"John"})
+            finds all models with name = John
+
+        find(order_by=["name"])
+            finds all models ordered by `name` column
+
+        find(order_by=[("name", SortDirection.DESC)])
+            finds all models with reversed order by `name` column
+
+        :param search_params: A mapping containing equality filters
+        :type search_params: Mapping
+        :param order_by:
+        :type order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]]
+        :return: A collection of models
+        :rtype: List
+        """
         ...
 
     def paginated_find(
         self,
         items_per_page: int,
-        page: int,
+        page: int = 1,
         search_params: Union[None, Mapping[str, Any]] = None,
         order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]] = None,
     ) -> PaginatedResult[MODEL]:
+        """Find models using filters and limit/offset pagination. Returned results
+        do include pagination metadata.
+
+        E.g.
+        paginated_find(search_params={"name":"John"})
+            finds all models with name = John
+
+        paginated_find(50, search_params={"name":"John"})
+            finds first 50 models with name = John
+
+        paginated_find(50, 3, search_params={"name":"John"})
+            finds 50 models with name = John, skipping 2 pages (100)
+
+        paginated_find(order_by=["name"])
+            finds all models ordered by `name` column
+
+        paginated_find(order_by=[("name", SortDirection.DESC)])
+            finds all models with reversed order by `name` column
+
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
+        :param page: Page to retrieve
+        :type page: int
+        :param search_params: A mapping containing equality filters
+        :type search_params: Mapping
+        :param order_by:
+        :type order_by: Union[None, Iterable[Union[str, Tuple[str, SortDirection]]]]
+        :return: A collection of models
+        :rtype: List
+        """
         ...
 
     def cursor_paginated_find(
@@ -98,4 +271,33 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
         is_before_cursor: bool = False,
         search_params: Union[None, Mapping[str, Any]] = None,
     ) -> CursorPaginatedResult[MODEL]:
+        """Find models using filters and cursor based pagination. Returned results
+        do include pagination metadata.
+
+        E.g.
+        cursor_paginated_find(search_params={"name":"John"})
+            finds all models with name = John
+
+        cursor_paginated_find(50, search_params={"name":"John"})
+            finds first 50 models with name = John
+
+        cursor_paginated_find(50, CursorReference(column="id", value=123))
+            finds first 50 models after the one with "id" 123
+
+        cursor_paginated_find(50, CursorReference(column="id", value=123), True)
+            finds last 50 models before the one with "id" 123
+
+        :param items_per_page: Number of models to retrieve
+        :type items_per_page: int
+        :param cursor_reference: A cursor reference containing ordering column
+            and threshold value
+        :type cursor_reference: Union[CursorReference, None]
+        :param is_before_cursor: If True it will return items before the cursor,
+            otherwise items after
+        :type is_before_cursor: bool
+        :param search_params: A mapping containing equality filters
+        :type search_params: Mapping
+        :return: A collection of models
+        :rtype: List
+        """
         ...

--- a/sqlalchemy_bind_manager/repository.py
+++ b/sqlalchemy_bind_manager/repository.py
@@ -6,3 +6,7 @@ from ._repository import (
     SQLAlchemyAsyncRepository,
     SQLAlchemyRepository,
 )
+from ._unit_of_work import (
+    AsyncUnitOfWork,
+    UnitOfWork,
+)

--- a/sqlalchemy_bind_manager/repository.py
+++ b/sqlalchemy_bind_manager/repository.py
@@ -1,6 +1,6 @@
 from ._repository import (
-    Cursor,
     CursorPaginatedResult,
+    CursorReference,
     PaginatedResult,
     SortDirection,
     SQLAlchemyAsyncRepository,

--- a/sqlalchemy_bind_manager/repository.py
+++ b/sqlalchemy_bind_manager/repository.py
@@ -1,0 +1,8 @@
+from ._repository import (
+    Cursor,
+    CursorPaginatedResult,
+    PaginatedResult,
+    SortDirection,
+    SQLAlchemyAsyncRepository,
+    SQLAlchemyRepository,
+)

--- a/tests/repository/async_/conftest.py
+++ b/tests/repository/async_/conftest.py
@@ -39,7 +39,9 @@ def repository_class(model_class) -> Type[SQLAlchemyAsyncRepository]:
 
 
 @pytest.fixture
-def repository_class_string_pk(model_class_string_pk) -> Type[SQLAlchemyAsyncRepository]:
+def repository_class_string_pk(
+    model_class_string_pk,
+) -> Type[SQLAlchemyAsyncRepository]:
     class MyRepository(SQLAlchemyAsyncRepository[model_class]):
         _model = model_class_string_pk
 

--- a/tests/repository/async_/conftest.py
+++ b/tests/repository/async_/conftest.py
@@ -8,9 +8,9 @@ from sqlalchemy.orm import clear_mappers, relationship
 
 from sqlalchemy_bind_manager import (
     SQLAlchemyAsyncConfig,
-    SQLAlchemyAsyncRepository,
     SQLAlchemyBindManager,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyAsyncRepository
 
 
 @pytest.fixture

--- a/tests/repository/async_/conftest.py
+++ b/tests/repository/async_/conftest.py
@@ -39,6 +39,14 @@ def repository_class(model_class) -> Type[SQLAlchemyAsyncRepository]:
 
 
 @pytest.fixture
+def repository_class_string_pk(model_class_string_pk) -> Type[SQLAlchemyAsyncRepository]:
+    class MyRepository(SQLAlchemyAsyncRepository[model_class]):
+        _model = model_class_string_pk
+
+    return MyRepository
+
+
+@pytest.fixture
 def related_repository_class(related_model_classes) -> Type[SQLAlchemyAsyncRepository]:
     class ParentRepository(SQLAlchemyAsyncRepository[related_model_classes[0]]):
         _model = related_model_classes[0]
@@ -54,6 +62,22 @@ async def model_class(sa_manager):
         __tablename__ = "mymodel"
 
         model_id = Column(Integer, primary_key=True, autoincrement=True)
+        name = Column(String)
+
+    async with default_bind.engine.begin() as conn:
+        await conn.run_sync(default_bind.registry_mapper.metadata.create_all)
+
+    yield MyModel
+
+
+@pytest.fixture
+async def model_class_string_pk(sa_manager):
+    default_bind = sa_manager.get_bind()
+
+    class MyModel(default_bind.model_declarative_base):
+        __tablename__ = "mymodel_string_pk"
+
+        model_id = Column(String, primary_key=True)
         name = Column(String)
 
     async with default_bind.engine.begin() as conn:

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -24,10 +24,13 @@ def _test_models(model_class):
     ]
 
 
-@pytest.mark.parametrize(["items_per_page", "expected_next_page"], [
-    [2, True],
-    [4, False],
-])
+@pytest.mark.parametrize(
+    ["items_per_page", "expected_next_page"],
+    [
+        [2, True],
+        [4, False],
+    ],
+)
 async def test_paginated_find_without_cursor(
     repository_class, model_class, sa_manager, items_per_page, expected_next_page
 ):
@@ -59,8 +62,7 @@ async def test_paginated_find_without_query_result(
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        items_per_page=2,
-        search_params=dict(name="Unknown")
+        items_per_page=2, search_params=dict(name="Unknown")
     )
     assert len(results.items) == 0
     assert results.page_info.items_per_page == 2
@@ -71,14 +73,18 @@ async def test_paginated_find_without_query_result(
     assert results.page_info.end_cursor is None
 
 
-async def test_paginated_find_accepts_encoded_cursors(repository_class, model_class, sa_manager):
+async def test_paginated_find_accepts_encoded_cursors(
+    repository_class, model_class, sa_manager
+):
     repo = repository_class(sa_manager.get_bind())
     await repo.save_many(_test_models(model_class))
     results = await repo.cursor_paginated_find(
-        reference_cursor=repo.encode_cursor(Cursor(
-            column="model_id",
-            value=80,
-        )),
+        reference_cursor=repo.encode_cursor(
+            Cursor(
+                column="model_id",
+                value=80,
+            )
+        ),
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -229,26 +235,26 @@ async def test_paginated_find_previous_next_page(
 @pytest.mark.parametrize(
     ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
     [
-        (None, '000', True, False, ['100', '110']),
-        (None, '100', True, True, ['110', '80']),
-        (None, '105', True, True, ['110', '80']),
-        (None, '110', False, True, ['80', '90']),
-        (None, '115', False, True, ['80', '90']),
-        (None, '75', False, True, ['80', '90']),
-        (None, '80', False, True, ['90']),
-        (None, '85', False, True, ['90']),
-        (None, '90', False, True, []),
-        (None, '95', False, True, []),
-        ('95', None, False, True, ['80', '90']),
-        ('90', None, True, True, ['110', '80']),
-        ('85', None, True, True, ['110', '80']),
-        ('80', None, True, False, ['100', '110']),
-        ('75', None, True, False, ['100', '110']),
-        ('115', None, True, False, ['100', '110']),
-        ('110', None, True, False, ['100']),
-        ('105', None, True, False, ['100']),
-        ('100', None, True, False, []),
-        ('000', None, True, False, []),
+        (None, "000", True, False, ["100", "110"]),
+        (None, "100", True, True, ["110", "80"]),
+        (None, "105", True, True, ["110", "80"]),
+        (None, "110", False, True, ["80", "90"]),
+        (None, "115", False, True, ["80", "90"]),
+        (None, "75", False, True, ["80", "90"]),
+        (None, "80", False, True, ["90"]),
+        (None, "85", False, True, ["90"]),
+        (None, "90", False, True, []),
+        (None, "95", False, True, []),
+        ("95", None, False, True, ["80", "90"]),
+        ("90", None, True, True, ["110", "80"]),
+        ("85", None, True, True, ["110", "80"]),
+        ("80", None, True, False, ["100", "110"]),
+        ("75", None, True, False, ["100", "110"]),
+        ("115", None, True, False, ["100", "110"]),
+        ("110", None, True, False, ["100"]),
+        ("105", None, True, False, ["100"]),
+        ("100", None, True, False, []),
+        ("000", None, True, False, []),
     ],
 )
 async def test_paginated_find_string_pk(

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sqlalchemy_bind_manager._repository.base_repository import Cursor
+from sqlalchemy_bind_manager.repository import Cursor
 
 
 def _test_models(model_class):

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -104,7 +104,7 @@ async def test_paginated_find_page_length_before(
             column="model_id",
             value=110,
         ),
-        is_end_cursor=True,
+        is_before_cursor=True,
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -192,7 +192,7 @@ async def test_paginated_find_previous_next_page(
             column="model_id",
             value=after or before,
         ),
-        is_end_cursor=bool(before),
+        is_before_cursor=bool(before),
         items_per_page=2,
     )
 
@@ -254,7 +254,7 @@ async def test_paginated_find_string_pk(
             column="model_id",
             value=after or before,
         ),
-        is_end_cursor=bool(before),
+        is_before_cursor=bool(before),
         items_per_page=2,
     )
 

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,5 +1,7 @@
 import pytest
 
+from sqlalchemy_bind_manager._repository.common import Cursor
+
 
 def _test_models(model_class):
     return [
@@ -18,17 +20,21 @@ def _test_models(model_class):
         model_class(
             model_id=40,
             name="NoOne",
-        )
+        ),
     ]
 
 
-async def test_paginated_find_page_length_after(repository_class, model_class, sa_manager):
+async def test_paginated_find_page_length_after(
+    repository_class, model_class, sa_manager
+):
     repo = repository_class(sa_manager.get_bind())
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        order_by="model_id",
-        after=10,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=10,
+        ),
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -45,8 +51,11 @@ async def test_paginated_find_page_length_before(
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        order_by="model_id",
-        before=40,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=40,
+        ),
+        is_end_cursor=True,
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -54,24 +63,6 @@ async def test_paginated_find_page_length_before(
     assert results.items[1].name == "StillSomeoneElse"
     assert results.page_info.items_per_page == 2
     assert results.page_info.total_items == 4
-
-
-async def test_paginated_find_must_use_either_after_or_before(
-    repository_class, sa_manager
-):
-    repo = repository_class(sa_manager.get_bind())
-    with pytest.raises(ValueError):
-        await repo.cursor_paginated_find(
-            order_by="model_id",
-            after=1,
-            before=4,
-            items_per_page=2,
-        )
-    with pytest.raises(ValueError):
-        await repo.cursor_paginated_find(
-            order_by="model_id",
-            items_per_page=2,
-        )
 
 
 async def test_paginated_find_max_page_length_is_respected(
@@ -82,8 +73,10 @@ async def test_paginated_find_max_page_length_is_respected(
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        order_by="model_id",
-        after=10,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=10,
+        ),
         items_per_page=50,
     )
     assert len(results.items) == 2
@@ -93,15 +86,15 @@ async def test_paginated_find_max_page_length_is_respected(
     assert results.page_info.total_items == 4
 
 
-async def test_paginated_find_empty_result(
-    repository_class, model_class, sa_manager
-):
+async def test_paginated_find_empty_result(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        order_by="model_id",
-        after=40,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=40,
+        ),
         items_per_page=2,
     )
     assert len(results.items) == 0
@@ -109,43 +102,59 @@ async def test_paginated_find_empty_result(
     assert results.page_info.total_items == 4
 
 
-@pytest.mark.parametrize(["before", "after", "has_next_page", "has_previous_page", "returned_ids"], [
-    (None, 5, True, False, [10, 20]),
-    (None, 10, True, True, [20, 30]),
-    (None, 15, True, True, [20, 30]),
-    (None, 20, False, True, [30, 40]),
-    (None, 25, False, True, [30, 40]),
-    (None, 30, False, True, [40]),
-    (None, 35, False, True, [40]),
-    (None, 40, False, True, []),
-    (None, 45, False, True, []),
-    (45, None, False, True, [30, 40]),
-    (40, None, True, True, [20, 30]),
-    (35, None, True, True, [20, 30]),
-    (30, None, True, False, [10, 20]),
-    (25, None, True, False, [10, 20]),
-    (20, None, True, False, [10]),
-    (15, None, True, False, [10]),
-    (10, None, True, False, []),
-    (5, None, True, False, []),
-])
+@pytest.mark.parametrize(
+    ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
+    [
+        (None, 5, True, False, [10, 20]),
+        (None, 10, True, True, [20, 30]),
+        (None, 15, True, True, [20, 30]),
+        (None, 20, False, True, [30, 40]),
+        (None, 25, False, True, [30, 40]),
+        (None, 30, False, True, [40]),
+        (None, 35, False, True, [40]),
+        (None, 40, False, True, []),
+        (None, 45, False, True, []),
+        (45, None, False, True, [30, 40]),
+        (40, None, True, True, [20, 30]),
+        (35, None, True, True, [20, 30]),
+        (30, None, True, False, [10, 20]),
+        (25, None, True, False, [10, 20]),
+        (20, None, True, False, [10]),
+        (15, None, True, False, [10]),
+        (10, None, True, False, []),
+        (5, None, True, False, []),
+    ],
+)
 async def test_paginated_find_previous_next_page(
-    repository_class, model_class, sa_manager, before, after, has_next_page, has_previous_page, returned_ids
+    repository_class,
+    model_class,
+    sa_manager,
+    before,
+    after,
+    has_next_page,
+    has_previous_page,
+    returned_ids,
 ):
     repo = repository_class(sa_manager.get_bind())
     await repo.save_many(_test_models(model_class))
 
     result = await repo.cursor_paginated_find(
-        order_by="model_id",
-        before=before,
-        after=after,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=after or before,
+        ),
+        is_end_cursor=bool(before),
         items_per_page=2,
     )
 
     assert len(returned_ids) == len(result.items)
     if len(returned_ids):
-        assert result.page_info.start_cursor == str(result.items[0].model_id)
-        assert result.page_info.end_cursor == str(result.items[-1].model_id)
+        assert result.page_info.start_cursor == repo.encode_cursor(
+            Cursor(value=result.items[0].model_id, column="model_id")
+        )
+        assert result.page_info.end_cursor == repo.encode_cursor(
+            Cursor(value=result.items[-1].model_id, column="model_id")
+        )
     for k, v in enumerate(returned_ids):
         assert result.items[k].model_id == v
     assert result.page_info.has_next_page == has_next_page

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,23 +1,61 @@
+from sqlalchemy_bind_manager import SortDirection
+
+
 async def test_paginated_find_page_length(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
+        model_id=1,
         name="Someone",
     )
     await repo.save(model)
     model2 = model_class(
+        model_id=2,
         name="SomeoneElse",
     )
     await repo.save(model2)
     model3 = model_class(
+        model_id=3,
         name="StillSomeoneElse",
     )
     await repo.save(model3)
 
-    results = await repo.paginated_find(page=1, items_per_page=2)
+    results = await repo.cursor_paginated_find(
+        after=("model_id", 1), items_per_page=2
+    )
     assert len(results.items) == 2
-    assert results.items[0].name == "Someone"
-    assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "StillSomeoneElse"
+    assert results.page is None
+    assert results.items_per_page == 2
+    assert results.total_items == 3
+    assert results.total_pages == 2
+
+
+async def test_paginated_find_reverse_page_length(repository_class, model_class, sa_manager):
+    repo = repository_class(sa_manager.get_bind())
+    model = model_class(
+        model_id=1,
+        name="Someone",
+    )
+    await repo.save(model)
+    model2 = model_class(
+        model_id=2,
+        name="SomeoneElse",
+    )
+    await repo.save(model2)
+    model3 = model_class(
+        model_id=3,
+        name="StillSomeoneElse",
+    )
+    await repo.save(model3)
+
+    results = await repo.cursor_paginated_find(
+        after=("model_id", 3), items_per_page=2, direction=SortDirection.DESC
+    )
+    assert len(results.items) == 2
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "Someone"
+    assert results.page is None
     assert results.items_per_page == 2
     assert results.total_items == 3
     assert results.total_pages == 2
@@ -41,17 +79,19 @@ async def test_paginated_find_max_page_length_is_respected(
     )
     await repo.save(model3)
 
-    results = await repo.paginated_find(page=1, items_per_page=50)
+    results = await repo.cursor_paginated_find(
+        after=("model_id", 1), items_per_page=50
+    )
     assert len(results.items) == 2
-    assert results.items[0].name == "Someone"
-    assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "StillSomeoneElse"
+    assert results.page is None
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
 
 
-async def test_paginated_find_last_page(repository_class, model_class, sa_manager):
+async def test_paginated_find_after_last_item(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
         name="Someone",
@@ -66,43 +106,17 @@ async def test_paginated_find_last_page(repository_class, model_class, sa_manage
     )
     await repo.save(model3)
 
-    results = await repo.paginated_find(page=2, items_per_page=2)
-    assert len(results.items) == 1
-    assert results.items[0].name == "StillSomeoneElse"
-    assert results.page == 2
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-
-
-async def test_paginated_find_after_last_page(
-    repository_class, model_class, sa_manager
-):
-    repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        name="Someone",
+    results = await repo.cursor_paginated_find(
+        after=("model_id", 3), items_per_page=2
     )
-    await repo.save(model)
-    model2 = model_class(
-        name="SomeoneElse",
-    )
-    await repo.save(model2)
-    model3 = model_class(
-        name="StillSomeoneElse",
-    )
-    await repo.save(model3)
-
-    results = await repo.paginated_find(page=4, items_per_page=2)
     assert len(results.items) == 0
-    assert results.page == 0
+    assert results.page is None
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
 
 
-async def test_paginated_find_no_result_filters(
-    repository_class, model_class, sa_manager
-):
+async def test_paginated_find_no_result_filters(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
         name="Someone",
@@ -117,9 +131,7 @@ async def test_paginated_find_no_result_filters(
     )
     await repo.save(model3)
 
-    results = await repo.paginated_find(
-        page=1, items_per_page=2, search_params={"name": "Goofy"}
-    )
+    results = await repo.paginated_find(page=1, items_per_page=2, search_params={"name": "Goofy"})
     assert len(results.items) == 0
     assert results.page == 0
     assert results.items_per_page == 2

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sqlalchemy_bind_manager._repository.common import Cursor
+from sqlalchemy_bind_manager._repository.base_repository import Cursor
 
 
 def _test_models(model_class):

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,4 +1,4 @@
-from sqlalchemy_bind_manager import SortDirection
+import pytest
 
 
 async def test_paginated_find_page_length(repository_class, model_class, sa_manager):
@@ -18,20 +18,29 @@ async def test_paginated_find_page_length(repository_class, model_class, sa_mana
         name="StillSomeoneElse",
     )
     await repo.save(model3)
+    model4 = model_class(
+        model_id=4,
+        name="NoOne",
+    )
+    await repo.save(model4)
 
     results = await repo.cursor_paginated_find(
-        after=("model_id", 1), items_per_page=2
+        order_by="model_id",
+        after=1,
+        items_per_page=2,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.page is None
     assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.total_pages == 2
+    assert results.total_items == 4
+    assert results.has_next_page is True
+    assert results.has_previous_page is True
 
 
-async def test_paginated_find_reverse_page_length(repository_class, model_class, sa_manager):
+async def test_paginated_find_reverse_page_length(
+    repository_class, model_class, sa_manager
+):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
         model_id=1,
@@ -48,17 +57,42 @@ async def test_paginated_find_reverse_page_length(repository_class, model_class,
         name="StillSomeoneElse",
     )
     await repo.save(model3)
+    model4 = model_class(
+        model_id=4,
+        name="NoOne",
+    )
+    await repo.save(model4)
 
     results = await repo.cursor_paginated_find(
-        after=("model_id", 3), items_per_page=2, direction=SortDirection.DESC
+        order_by="model_id",
+        before=4,
+        items_per_page=2,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
-    assert results.items[1].name == "Someone"
-    assert results.page is None
+    assert results.items[1].name == "StillSomeoneElse"
     assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.total_pages == 2
+    assert results.total_items == 4
+    assert results.has_next_page is True
+    assert results.has_previous_page is True
+
+
+async def test_paginated_find_must_use_either_after_or_before(
+    repository_class, model_class, sa_manager
+):
+    repo = repository_class(sa_manager.get_bind())
+    with pytest.raises(ValueError):
+        await repo.cursor_paginated_find(
+            order_by="model_id",
+            after=1,
+            before=4,
+            items_per_page=2,
+        )
+    with pytest.raises(ValueError):
+        await repo.cursor_paginated_find(
+            order_by="model_id",
+            items_per_page=2,
+        )
 
 
 async def test_paginated_find_max_page_length_is_respected(
@@ -80,18 +114,22 @@ async def test_paginated_find_max_page_length_is_respected(
     await repo.save(model3)
 
     results = await repo.cursor_paginated_find(
-        after=("model_id", 1), items_per_page=50
+        order_by="model_id",
+        after=1,
+        items_per_page=50,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.page is None
     assert results.items_per_page == 2
-    assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is False
+    assert results.has_previous_page is True
 
 
-async def test_paginated_find_after_last_item(repository_class, model_class, sa_manager):
+async def test_paginated_find_after_last_item(
+    repository_class, model_class, sa_manager
+):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
         name="Someone",
@@ -107,33 +145,12 @@ async def test_paginated_find_after_last_item(repository_class, model_class, sa_
     await repo.save(model3)
 
     results = await repo.cursor_paginated_find(
-        after=("model_id", 3), items_per_page=2
+        order_by="model_id",
+        after=3,
+        items_per_page=2,
     )
     assert len(results.items) == 0
-    assert results.page is None
     assert results.items_per_page == 2
-    assert results.total_pages == 2
     assert results.total_items == 3
-
-
-async def test_paginated_find_no_result_filters(repository_class, model_class, sa_manager):
-    repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        name="Someone",
-    )
-    await repo.save(model)
-    model2 = model_class(
-        name="SomeoneElse",
-    )
-    await repo.save(model2)
-    model3 = model_class(
-        name="StillSomeoneElse",
-    )
-    await repo.save(model3)
-
-    results = await repo.paginated_find(page=1, items_per_page=2, search_params={"name": "Goofy"})
-    assert len(results.items) == 0
-    assert results.page == 0
-    assert results.items_per_page == 2
-    assert results.total_pages == 0
-    assert results.total_items == 0
+    assert results.has_next_page is False
+    assert results.has_previous_page is True

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,84 +1,63 @@
 import pytest
 
 
-async def test_paginated_find_page_length(repository_class, model_class, sa_manager):
+def _test_models(model_class):
+    return [
+        model_class(
+            model_id=10,
+            name="Someone",
+        ),
+        model_class(
+            model_id=20,
+            name="SomeoneElse",
+        ),
+        model_class(
+            model_id=30,
+            name="StillSomeoneElse",
+        ),
+        model_class(
+            model_id=40,
+            name="NoOne",
+        )
+    ]
+
+
+async def test_paginated_find_page_length_after(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        model_id=1,
-        name="Someone",
-    )
-    await repo.save(model)
-    model2 = model_class(
-        model_id=2,
-        name="SomeoneElse",
-    )
-    await repo.save(model2)
-    model3 = model_class(
-        model_id=3,
-        name="StillSomeoneElse",
-    )
-    await repo.save(model3)
-    model4 = model_class(
-        model_id=4,
-        name="NoOne",
-    )
-    await repo.save(model4)
+    await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
         order_by="model_id",
-        after=1,
+        after=10,
         items_per_page=2,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.items_per_page == 2
-    assert results.total_items == 4
-    assert results.has_next_page is True
-    assert results.has_previous_page is True
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 4
 
 
-async def test_paginated_find_reverse_page_length(
+async def test_paginated_find_page_length_before(
     repository_class, model_class, sa_manager
 ):
     repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        model_id=1,
-        name="Someone",
-    )
-    await repo.save(model)
-    model2 = model_class(
-        model_id=2,
-        name="SomeoneElse",
-    )
-    await repo.save(model2)
-    model3 = model_class(
-        model_id=3,
-        name="StillSomeoneElse",
-    )
-    await repo.save(model3)
-    model4 = model_class(
-        model_id=4,
-        name="NoOne",
-    )
-    await repo.save(model4)
+    await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
         order_by="model_id",
-        before=4,
+        before=40,
         items_per_page=2,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.items_per_page == 2
-    assert results.total_items == 4
-    assert results.has_next_page is True
-    assert results.has_previous_page is True
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 4
 
 
 async def test_paginated_find_must_use_either_after_or_before(
-    repository_class, model_class, sa_manager
+    repository_class, sa_manager
 ):
     repo = repository_class(sa_manager.get_bind())
     with pytest.raises(ValueError):
@@ -100,57 +79,74 @@ async def test_paginated_find_max_page_length_is_respected(
 ):
     repo = repository_class(sa_manager.get_bind())
     repo._max_query_limit = 2
-    model = model_class(
-        name="Someone",
-    )
-    await repo.save(model)
-    model2 = model_class(
-        name="SomeoneElse",
-    )
-    await repo.save(model2)
-    model3 = model_class(
-        name="StillSomeoneElse",
-    )
-    await repo.save(model3)
+    await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
         order_by="model_id",
-        after=1,
+        after=10,
         items_per_page=50,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.has_next_page is False
-    assert results.has_previous_page is True
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 4
 
 
-async def test_paginated_find_after_last_item(
+async def test_paginated_find_empty_result(
     repository_class, model_class, sa_manager
 ):
     repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        name="Someone",
-    )
-    await repo.save(model)
-    model2 = model_class(
-        name="SomeoneElse",
-    )
-    await repo.save(model2)
-    model3 = model_class(
-        name="StillSomeoneElse",
-    )
-    await repo.save(model3)
+    await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
         order_by="model_id",
-        after=3,
+        after=40,
         items_per_page=2,
     )
     assert len(results.items) == 0
-    assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.has_next_page is False
-    assert results.has_previous_page is True
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 4
+
+
+@pytest.mark.parametrize(["before", "after", "has_next_page", "has_previous_page", "returned_ids"], [
+    (None, 5, True, False, [10, 20]),
+    (None, 10, True, True, [20, 30]),
+    (None, 15, True, True, [20, 30]),
+    (None, 20, False, True, [30, 40]),
+    (None, 25, False, True, [30, 40]),
+    (None, 30, False, True, [40]),
+    (None, 35, False, True, [40]),
+    (None, 40, False, True, []),
+    (None, 45, False, True, []),
+    (45, None, False, True, [30, 40]),
+    (40, None, True, True, [20, 30]),
+    (35, None, True, True, [20, 30]),
+    (30, None, True, False, [10, 20]),
+    (25, None, True, False, [10, 20]),
+    (20, None, True, False, [10]),
+    (15, None, True, False, [10]),
+    (10, None, True, False, []),
+    (5, None, True, False, []),
+])
+async def test_paginated_find_previous_next_page(
+    repository_class, model_class, sa_manager, before, after, has_next_page, has_previous_page, returned_ids
+):
+    repo = repository_class(sa_manager.get_bind())
+    await repo.save_many(_test_models(model_class))
+
+    result = await repo.cursor_paginated_find(
+        order_by="model_id",
+        before=before,
+        after=after,
+        items_per_page=2,
+    )
+
+    assert len(returned_ids) == len(result.items)
+    if len(returned_ids):
+        assert result.page_info.start_cursor == str(result.items[0].model_id)
+        assert result.page_info.end_cursor == str(result.items[-1].model_id)
+    for k, v in enumerate(returned_ids):
+        assert result.items[k].model_id == v
+    assert result.page_info.has_next_page == has_next_page
+    assert result.page_info.has_previous_page == has_previous_page

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -6,19 +6,19 @@ from sqlalchemy_bind_manager._repository.common import Cursor
 def _test_models(model_class):
     return [
         model_class(
-            model_id=10,
+            model_id=80,
             name="Someone",
         ),
         model_class(
-            model_id=20,
+            model_id=90,
             name="SomeoneElse",
         ),
         model_class(
-            model_id=30,
+            model_id=100,
             name="StillSomeoneElse",
         ),
         model_class(
-            model_id=40,
+            model_id=110,
             name="NoOne",
         ),
     ]
@@ -52,6 +52,25 @@ async def test_paginated_find_without_cursor(
     )
 
 
+async def test_paginated_find_without_query_result(
+    repository_class, model_class, sa_manager
+):
+    repo = repository_class(sa_manager.get_bind())
+    await repo.save_many(_test_models(model_class))
+
+    results = await repo.cursor_paginated_find(
+        items_per_page=2,
+        search_params=dict(name="Unknown")
+    )
+    assert len(results.items) == 0
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 0
+    assert results.page_info.has_next_page is False
+    assert results.page_info.has_previous_page is False
+    assert results.page_info.start_cursor is None
+    assert results.page_info.end_cursor is None
+
+
 async def test_paginated_find_page_length_after(
     repository_class, model_class, sa_manager
 ):
@@ -61,7 +80,7 @@ async def test_paginated_find_page_length_after(
     results = await repo.cursor_paginated_find(
         reference_cursor=Cursor(
             column="model_id",
-            value=10,
+            value=80,
         ),
         items_per_page=2,
     )
@@ -81,7 +100,7 @@ async def test_paginated_find_page_length_before(
     results = await repo.cursor_paginated_find(
         reference_cursor=Cursor(
             column="model_id",
-            value=40,
+            value=110,
         ),
         is_end_cursor=True,
         items_per_page=2,
@@ -103,7 +122,7 @@ async def test_paginated_find_max_page_length_is_respected(
     results = await repo.cursor_paginated_find(
         reference_cursor=Cursor(
             column="model_id",
-            value=10,
+            value=80,
         ),
         items_per_page=50,
     )
@@ -121,7 +140,7 @@ async def test_paginated_find_empty_result(repository_class, model_class, sa_man
     results = await repo.cursor_paginated_find(
         reference_cursor=Cursor(
             column="model_id",
-            value=40,
+            value=110,
         ),
         items_per_page=2,
     )
@@ -133,24 +152,24 @@ async def test_paginated_find_empty_result(repository_class, model_class, sa_man
 @pytest.mark.parametrize(
     ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
     [
-        (None, 5, True, False, [10, 20]),
-        (None, 10, True, True, [20, 30]),
-        (None, 15, True, True, [20, 30]),
-        (None, 20, False, True, [30, 40]),
-        (None, 25, False, True, [30, 40]),
-        (None, 30, False, True, [40]),
-        (None, 35, False, True, [40]),
-        (None, 40, False, True, []),
-        (None, 45, False, True, []),
-        (45, None, False, True, [30, 40]),
-        (40, None, True, True, [20, 30]),
-        (35, None, True, True, [20, 30]),
-        (30, None, True, False, [10, 20]),
-        (25, None, True, False, [10, 20]),
-        (20, None, True, False, [10]),
-        (15, None, True, False, [10]),
-        (10, None, True, False, []),
-        (5, None, True, False, []),
+        (None, 75, True, False, [80, 90]),
+        (None, 80, True, True, [90, 100]),
+        (None, 85, True, True, [90, 100]),
+        (None, 90, False, True, [100, 110]),
+        (None, 95, False, True, [100, 110]),
+        (None, 100, False, True, [110]),
+        (None, 105, False, True, [110]),
+        (None, 110, False, True, []),
+        (None, 115, False, True, []),
+        (115, None, False, True, [100, 110]),
+        (110, None, True, True, [90, 100]),
+        (105, None, True, True, [90, 100]),
+        (100, None, True, False, [80, 90]),
+        (95, None, True, False, [80, 90]),
+        (90, None, True, False, [80]),
+        (85, None, True, False, [80]),
+        (80, None, True, False, []),
+        (75, None, True, False, []),
     ],
 )
 async def test_paginated_find_previous_next_page(

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sqlalchemy_bind_manager.repository import Cursor
+from sqlalchemy_bind_manager.repository import CursorReference
 
 
 def _test_models(model_class):
@@ -47,11 +47,11 @@ async def test_paginated_find_without_cursor(
     assert results.page_info.total_items == 4
     assert results.page_info.has_next_page is expected_next_page
     assert results.page_info.has_previous_page is False
-    assert results.page_info.start_cursor == repo.encode_cursor(
-        Cursor(value=results.items[0].model_id, column="model_id")
+    assert results.page_info.start_cursor == CursorReference(
+        value=results.items[0].model_id, column="model_id"
     )
-    assert results.page_info.end_cursor == repo.encode_cursor(
-        Cursor(value=results.items[-1].model_id, column="model_id")
+    assert results.page_info.end_cursor == CursorReference(
+        value=results.items[-1].model_id, column="model_id"
     )
 
 
@@ -73,27 +73,6 @@ async def test_paginated_find_without_query_result(
     assert results.page_info.end_cursor is None
 
 
-async def test_paginated_find_accepts_encoded_cursors(
-    repository_class, model_class, sa_manager
-):
-    repo = repository_class(sa_manager.get_bind())
-    await repo.save_many(_test_models(model_class))
-    results = await repo.cursor_paginated_find(
-        reference_cursor=repo.encode_cursor(
-            Cursor(
-                column="model_id",
-                value=80,
-            )
-        ),
-        items_per_page=2,
-    )
-    assert len(results.items) == 2
-    assert results.items[0].name == "SomeoneElse"
-    assert results.items[1].name == "StillSomeoneElse"
-    assert results.page_info.items_per_page == 2
-    assert results.page_info.total_items == 4
-
-
 async def test_paginated_find_page_length_after(
     repository_class, model_class, sa_manager
 ):
@@ -101,7 +80,7 @@ async def test_paginated_find_page_length_after(
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=80,
         ),
@@ -121,7 +100,7 @@ async def test_paginated_find_page_length_before(
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=110,
         ),
@@ -143,7 +122,7 @@ async def test_paginated_find_max_page_length_is_respected(
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=80,
         ),
@@ -161,7 +140,7 @@ async def test_paginated_find_empty_result(repository_class, model_class, sa_man
     await repo.save_many(_test_models(model_class))
 
     results = await repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=110,
         ),
@@ -209,7 +188,7 @@ async def test_paginated_find_previous_next_page(
     await repo.save_many(_test_models(model_class))
 
     result = await repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=after or before,
         ),
@@ -219,11 +198,11 @@ async def test_paginated_find_previous_next_page(
 
     assert len(returned_ids) == len(result.items)
     if len(returned_ids):
-        assert result.page_info.start_cursor == repo.encode_cursor(
-            Cursor(value=result.items[0].model_id, column="model_id")
+        assert result.page_info.start_cursor == CursorReference(
+            value=result.items[0].model_id, column="model_id"
         )
-        assert result.page_info.end_cursor == repo.encode_cursor(
-            Cursor(value=result.items[-1].model_id, column="model_id")
+        assert result.page_info.end_cursor == CursorReference(
+            value=result.items[-1].model_id, column="model_id"
         )
     for k, v in enumerate(returned_ids):
         assert result.items[k].model_id == v
@@ -271,7 +250,7 @@ async def test_paginated_find_string_pk(
     await repo.save_many(_test_models(model_class_string_pk))
 
     result = await repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=after or before,
         ),
@@ -281,11 +260,11 @@ async def test_paginated_find_string_pk(
 
     assert len(returned_ids) == len(result.items)
     if len(returned_ids):
-        assert result.page_info.start_cursor == repo.encode_cursor(
-            Cursor(value=result.items[0].model_id, column="model_id")
+        assert result.page_info.start_cursor == CursorReference(
+            value=result.items[0].model_id, column="model_id"
         )
-        assert result.page_info.end_cursor == repo.encode_cursor(
-            Cursor(value=result.items[-1].model_id, column="model_id")
+        assert result.page_info.end_cursor == CursorReference(
+            value=result.items[-1].model_id, column="model_id"
         )
     for k, v in enumerate(returned_ids):
         assert result.items[k].model_id == v

--- a/tests/repository/async_/test_cursor_pagination.py
+++ b/tests/repository/async_/test_cursor_pagination.py
@@ -71,6 +71,23 @@ async def test_paginated_find_without_query_result(
     assert results.page_info.end_cursor is None
 
 
+async def test_paginated_find_accepts_encoded_cursors(repository_class, model_class, sa_manager):
+    repo = repository_class(sa_manager.get_bind())
+    await repo.save_many(_test_models(model_class))
+    results = await repo.cursor_paginated_find(
+        reference_cursor=repo.encode_cursor(Cursor(
+            column="model_id",
+            value=80,
+        )),
+        items_per_page=2,
+    )
+    assert len(results.items) == 2
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "StillSomeoneElse"
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 4
+
+
 async def test_paginated_find_page_length_after(
     repository_class, model_class, sa_manager
 ):

--- a/tests/repository/async_/test_find.py
+++ b/tests/repository/async_/test_find.py
@@ -1,7 +1,7 @@
 import pytest
 
-from sqlalchemy_bind_manager import SortDirection
 from sqlalchemy_bind_manager.exceptions import UnmappedProperty
+from sqlalchemy_bind_manager.repository import SortDirection
 
 
 async def test_find(repository_class, model_class, sa_manager):

--- a/tests/repository/async_/test_lifecycle.py
+++ b/tests/repository/async_/test_lifecycle.py
@@ -2,12 +2,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sqlalchemy_bind_manager import SQLAlchemyAsyncRepository
 from sqlalchemy_bind_manager.exceptions import (
     InvalidConfig,
     InvalidModel,
     UnsupportedBind,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyAsyncRepository
 
 
 def test_repository_fails_if_not_async_bind(sync_async_sa_manager, model_class):

--- a/tests/repository/async_/test_pagination.py
+++ b/tests/repository/async_/test_pagination.py
@@ -17,12 +17,12 @@ async def test_paginated_find_page_length(repository_class, model_class, sa_mana
     assert len(results.items) == 2
     assert results.items[0].name == "Someone"
     assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
-    assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.total_pages == 2
-    assert results.has_next_page is True
-    assert results.has_previous_page is False
+    assert results.page_info.page == 1
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.total_pages == 2
+    assert results.page_info.has_next_page is True
+    assert results.page_info.has_previous_page is False
 
 
 async def test_paginated_find_max_page_length_is_respected(
@@ -47,12 +47,12 @@ async def test_paginated_find_max_page_length_is_respected(
     assert len(results.items) == 2
     assert results.items[0].name == "Someone"
     assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-    assert results.has_next_page is True
-    assert results.has_previous_page is False
+    assert results.page_info.page == 1
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.has_next_page is True
+    assert results.page_info.has_previous_page is False
 
 
 async def test_paginated_find_last_page(repository_class, model_class, sa_manager):
@@ -73,12 +73,12 @@ async def test_paginated_find_last_page(repository_class, model_class, sa_manage
     results = await repo.paginated_find(page=2, items_per_page=2)
     assert len(results.items) == 1
     assert results.items[0].name == "StillSomeoneElse"
-    assert results.page == 2
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-    assert results.has_next_page is False
-    assert results.has_previous_page is True
+    assert results.page_info.page == 2
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.has_next_page is False
+    assert results.page_info.has_previous_page is True
 
 
 async def test_paginated_find_after_last_page(
@@ -100,11 +100,11 @@ async def test_paginated_find_after_last_page(
 
     results = await repo.paginated_find(page=4, items_per_page=2)
     assert len(results.items) == 0
-    assert results.page == 0
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-    assert results.has_next_page is False
+    assert results.page_info.page == 0
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.has_next_page is False
 
 
 async def test_paginated_find_no_result_filters(
@@ -128,9 +128,9 @@ async def test_paginated_find_no_result_filters(
         page=1, items_per_page=2, search_params={"name": "Goofy"}
     )
     assert len(results.items) == 0
-    assert results.page == 0
-    assert results.items_per_page == 2
-    assert results.total_pages == 0
-    assert results.total_items == 0
-    assert results.has_next_page is False
-    assert results.has_previous_page is False
+    assert results.page_info.page == 0
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 0
+    assert results.page_info.total_items == 0
+    assert results.page_info.has_next_page is False
+    assert results.page_info.has_previous_page is False

--- a/tests/repository/async_/test_pagination.py
+++ b/tests/repository/async_/test_pagination.py
@@ -21,6 +21,8 @@ async def test_paginated_find_page_length(repository_class, model_class, sa_mana
     assert results.items_per_page == 2
     assert results.total_items == 3
     assert results.total_pages == 2
+    assert results.has_next_page is True
+    assert results.has_previous_page is False
 
 
 async def test_paginated_find_max_page_length_is_respected(
@@ -49,6 +51,8 @@ async def test_paginated_find_max_page_length_is_respected(
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is True
+    assert results.has_previous_page is False
 
 
 async def test_paginated_find_last_page(repository_class, model_class, sa_manager):
@@ -73,6 +77,8 @@ async def test_paginated_find_last_page(repository_class, model_class, sa_manage
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is False
+    assert results.has_previous_page is True
 
 
 async def test_paginated_find_after_last_page(
@@ -98,6 +104,7 @@ async def test_paginated_find_after_last_page(
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is False
 
 
 async def test_paginated_find_no_result_filters(
@@ -125,3 +132,5 @@ async def test_paginated_find_no_result_filters(
     assert results.items_per_page == 2
     assert results.total_pages == 0
     assert results.total_items == 0
+    assert results.has_next_page is False
+    assert results.has_previous_page is False

--- a/tests/repository/result_presenters/test_composite_pk.py
+++ b/tests/repository/result_presenters/test_composite_pk.py
@@ -1,0 +1,13 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sqlalchemy_bind_manager._repository.result_presenters import _pk_from_result_object
+
+
+def test_exception_raised_if_multiple_primary_keys():
+    with patch(
+        "sqlalchemy_bind_manager._repository.result_presenters.inspect",
+        return_value=Mock(primary_key=["1", "2"]),
+    ), pytest.raises(NotImplementedError):
+        _pk_from_result_object("irrelevant")

--- a/tests/repository/result_presenters/test_cursor_paginated_result_presenter.py
+++ b/tests/repository/result_presenters/test_cursor_paginated_result_presenter.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+import pytest
+
+from sqlalchemy_bind_manager._repository import CursorReference
+from sqlalchemy_bind_manager._repository.result_presenters import (
+    CursorPaginatedResultPresenter,
+)
+
+
+@dataclass
+class MyModel:
+    model_id: int
+    name: str
+
+
+@pytest.mark.parametrize(["is_end_cursor"], [(True,), (False,)])
+def test_fails_if_reference_cursor_wrong_type(is_end_cursor):
+    with pytest.raises(TypeError):
+        CursorPaginatedResultPresenter.build_result(
+            result_items=[MyModel(model_id=1, name="test")],
+            total_items_count=10,
+            items_per_page=1,
+            cursor_reference=CursorReference(column="model_id", value="1"),
+            is_end_cursor=is_end_cursor,
+        )

--- a/tests/repository/result_presenters/test_cursor_paginated_result_presenter.py
+++ b/tests/repository/result_presenters/test_cursor_paginated_result_presenter.py
@@ -14,13 +14,13 @@ class MyModel:
     name: str
 
 
-@pytest.mark.parametrize(["is_end_cursor"], [(True,), (False,)])
-def test_fails_if_reference_cursor_wrong_type(is_end_cursor):
+@pytest.mark.parametrize(["is_before_cursor"], [(True,), (False,)])
+def test_fails_if_reference_cursor_wrong_type(is_before_cursor):
     with pytest.raises(TypeError):
         CursorPaginatedResultPresenter.build_result(
             result_items=[MyModel(model_id=1, name="test")],
             total_items_count=10,
             items_per_page=1,
             cursor_reference=CursorReference(column="model_id", value="1"),
-            is_end_cursor=is_end_cursor,
+            is_before_cursor=is_before_cursor,
         )

--- a/tests/repository/sync/conftest.py
+++ b/tests/repository/sync/conftest.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import clear_mappers, relationship
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyConfig,
-    SQLAlchemyRepository,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyRepository
 
 
 @pytest.fixture

--- a/tests/repository/sync/conftest.py
+++ b/tests/repository/sync/conftest.py
@@ -31,6 +31,14 @@ def sa_manager() -> SQLAlchemyBindManager:
 
 
 @pytest.fixture
+def repository_class_string_pk(model_class_string_pk) -> Type[SQLAlchemyRepository]:
+    class MyRepository(SQLAlchemyRepository[model_class]):
+        _model = model_class_string_pk
+
+    return MyRepository
+
+
+@pytest.fixture
 def repository_class(model_class) -> Type[SQLAlchemyRepository]:
     class MyRepository(SQLAlchemyRepository[model_class]):
         _model = model_class
@@ -58,6 +66,25 @@ def model_class(sa_manager) -> Type:
         __mapper_args__ = {"eager_defaults": True}
 
         model_id = Column(Integer, primary_key=True, autoincrement=True)
+        name = Column(String)
+
+    default_bind.registry_mapper.metadata.create_all(default_bind.engine)
+
+    return MyModel
+
+
+@pytest.fixture
+def model_class_string_pk(sa_manager) -> Type:
+    default_bind = sa_manager.get_bind()
+
+    class MyModel(default_bind.model_declarative_base):
+        __tablename__ = "mymodel_string_pk"
+        # required in order to access columns with server defaults
+        # or SQL expression defaults, subsequent to a flush, without
+        # triggering an expired load
+        __mapper_args__ = {"eager_defaults": True}
+
+        model_id = Column(String, primary_key=True)
         name = Column(String)
 
     default_bind.registry_mapper.metadata.create_all(default_bind.engine)

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sqlalchemy_bind_manager._repository.base_repository import Cursor
+from sqlalchemy_bind_manager.repository import Cursor
 
 
 def _test_models(model_class):

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sqlalchemy_bind_manager.repository import Cursor
+from sqlalchemy_bind_manager.repository import CursorReference
 
 
 def _test_models(model_class):
@@ -47,40 +47,16 @@ def test_paginated_find_without_cursor(
     assert results.page_info.total_items == 4
     assert results.page_info.has_next_page is expected_next_page
     assert results.page_info.has_previous_page is False
-    assert results.page_info.start_cursor == repo.encode_cursor(
-        Cursor(value=results.items[0].model_id, column="model_id")
+    assert results.page_info.start_cursor == CursorReference(
+        value=results.items[0].model_id, column="model_id"
     )
-    assert results.page_info.end_cursor == repo.encode_cursor(
-        Cursor(value=results.items[-1].model_id, column="model_id")
-    )
-
-
-def test_paginated_find_accepts_encoded_cursors(
-    repository_class, model_class, sa_manager
-):
-    repo = repository_class(sa_manager.get_bind())
-    repo.save_many(_test_models(model_class))
-    results = repo.cursor_paginated_find(
-        reference_cursor=repo.encode_cursor(
-            Cursor(
-                column="model_id",
-                value=80,
-            )
-        ),
-        items_per_page=2,
-    )
-    assert len(results.items) == 2
-    assert results.items[0].name == "SomeoneElse"
-    assert results.items[1].name == "StillSomeoneElse"
-    assert results.page_info.items_per_page == 2
-    assert results.page_info.total_items == 4
 
 
 def test_paginated_find_page_length_after(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))
     results = repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=80,
         ),
@@ -114,7 +90,7 @@ def test_paginated_find_page_length_before(repository_class, model_class, sa_man
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=110,
         ),
@@ -136,7 +112,7 @@ def test_paginated_find_max_page_length_is_respected(
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=80,
         ),
@@ -154,7 +130,7 @@ def test_paginated_find_after_last_item(repository_class, model_class, sa_manage
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=110,
         ),
@@ -204,7 +180,7 @@ def test_paginated_find_previous_next_page(
     repo.save_many(_test_models(model_class))
 
     result = repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=after or before,
         ),
@@ -214,11 +190,11 @@ def test_paginated_find_previous_next_page(
 
     assert len(returned_ids) == len(result.items)
     if len(returned_ids):
-        assert result.page_info.start_cursor == repo.encode_cursor(
-            Cursor(value=result.items[0].model_id, column="model_id")
+        assert result.page_info.start_cursor == CursorReference(
+            value=result.items[0].model_id, column="model_id"
         )
-        assert result.page_info.end_cursor == repo.encode_cursor(
-            Cursor(value=result.items[-1].model_id, column="model_id")
+        assert result.page_info.end_cursor == CursorReference(
+            value=result.items[-1].model_id, column="model_id"
         )
     for k, v in enumerate(returned_ids):
         assert result.items[k].model_id == v
@@ -266,7 +242,7 @@ def test_paginated_find_string_pk(
     repo.save_many(_test_models(model_class_string_pk))
 
     result = repo.cursor_paginated_find(
-        reference_cursor=Cursor(
+        cursor_reference=CursorReference(
             column="model_id",
             value=after or before,
         ),
@@ -276,11 +252,11 @@ def test_paginated_find_string_pk(
 
     assert len(returned_ids) == len(result.items)
     if len(returned_ids):
-        assert result.page_info.start_cursor == repo.encode_cursor(
-            Cursor(value=result.items[0].model_id, column="model_id")
+        assert result.page_info.start_cursor == CursorReference(
+            value=result.items[0].model_id, column="model_id"
         )
-        assert result.page_info.end_cursor == repo.encode_cursor(
-            Cursor(value=result.items[-1].model_id, column="model_id")
+        assert result.page_info.end_cursor == CursorReference(
+            value=result.items[-1].model_id, column="model_id"
         )
     for k, v in enumerate(returned_ids):
         assert result.items[k].model_id == v

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -1,23 +1,61 @@
+from sqlalchemy_bind_manager import SortDirection
+
+
 def test_paginated_find_page_length(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
+        model_id=1,
         name="Someone",
     )
     repo.save(model)
     model2 = model_class(
+        model_id=2,
         name="SomeoneElse",
     )
     repo.save(model2)
     model3 = model_class(
+        model_id=3,
         name="StillSomeoneElse",
     )
     repo.save(model3)
 
-    results = repo.paginated_find(page=1, items_per_page=2)
+    results = repo.cursor_paginated_find(
+        after=("model_id", 1), items_per_page=2
+    )
     assert len(results.items) == 2
-    assert results.items[0].name == "Someone"
-    assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "StillSomeoneElse"
+    assert results.page is None
+    assert results.items_per_page == 2
+    assert results.total_items == 3
+    assert results.total_pages == 2
+
+
+def test_paginated_find_reverse_page_length(repository_class, model_class, sa_manager):
+    repo = repository_class(sa_manager.get_bind())
+    model = model_class(
+        model_id=1,
+        name="Someone",
+    )
+    repo.save(model)
+    model2 = model_class(
+        model_id=2,
+        name="SomeoneElse",
+    )
+    repo.save(model2)
+    model3 = model_class(
+        model_id=3,
+        name="StillSomeoneElse",
+    )
+    repo.save(model3)
+
+    results = repo.cursor_paginated_find(
+        after=("model_id", 3), items_per_page=2, direction=SortDirection.DESC
+    )
+    assert len(results.items) == 2
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "Someone"
+    assert results.page is None
     assert results.items_per_page == 2
     assert results.total_items == 3
     assert results.total_pages == 2
@@ -41,17 +79,19 @@ def test_paginated_find_max_page_length_is_respected(
     )
     repo.save(model3)
 
-    results = repo.paginated_find(page=1, items_per_page=50)
+    results = repo.cursor_paginated_find(
+        after=("model_id", 1), items_per_page=50
+    )
     assert len(results.items) == 2
-    assert results.items[0].name == "Someone"
-    assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "StillSomeoneElse"
+    assert results.page is None
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
 
 
-def test_paginated_find_last_page(repository_class, model_class, sa_manager):
+def test_paginated_find_after_last_item(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     model = model_class(
         name="Someone",
@@ -66,33 +106,11 @@ def test_paginated_find_last_page(repository_class, model_class, sa_manager):
     )
     repo.save(model3)
 
-    results = repo.paginated_find(page=2, items_per_page=2)
-    assert len(results.items) == 1
-    assert results.items[0].name == "StillSomeoneElse"
-    assert results.page == 2
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-
-
-def test_paginated_find_after_last_page(repository_class, model_class, sa_manager):
-    repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        name="Someone",
+    results = repo.cursor_paginated_find(
+        after=("model_id", 3), items_per_page=2
     )
-    repo.save(model)
-    model2 = model_class(
-        name="SomeoneElse",
-    )
-    repo.save(model2)
-    model3 = model_class(
-        name="StillSomeoneElse",
-    )
-    repo.save(model3)
-
-    results = repo.paginated_find(page=4, items_per_page=2)
     assert len(results.items) == 0
-    assert results.page == 0
+    assert results.page is None
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -24,10 +24,13 @@ def _test_models(model_class):
     ]
 
 
-@pytest.mark.parametrize(["items_per_page", "expected_next_page"], [
-    [2, True],
-    [4, False],
-])
+@pytest.mark.parametrize(
+    ["items_per_page", "expected_next_page"],
+    [
+        [2, True],
+        [4, False],
+    ],
+)
 def test_paginated_find_without_cursor(
     repository_class, model_class, sa_manager, items_per_page, expected_next_page
 ):
@@ -52,14 +55,18 @@ def test_paginated_find_without_cursor(
     )
 
 
-def test_paginated_find_accepts_encoded_cursors(repository_class, model_class, sa_manager):
+def test_paginated_find_accepts_encoded_cursors(
+    repository_class, model_class, sa_manager
+):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))
     results = repo.cursor_paginated_find(
-        reference_cursor=repo.encode_cursor(Cursor(
-            column="model_id",
-            value=80,
-        )),
+        reference_cursor=repo.encode_cursor(
+            Cursor(
+                column="model_id",
+                value=80,
+            )
+        ),
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -86,15 +93,12 @@ def test_paginated_find_page_length_after(repository_class, model_class, sa_mana
     assert results.page_info.total_items == 4
 
 
-def test_paginated_find_without_query_result(
-    repository_class, model_class, sa_manager
-):
+def test_paginated_find_without_query_result(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        items_per_page=2,
-        search_params=dict(name="Unknown")
+        items_per_page=2, search_params=dict(name="Unknown")
     )
     assert len(results.items) == 0
     assert results.page_info.items_per_page == 2
@@ -226,26 +230,26 @@ def test_paginated_find_previous_next_page(
 @pytest.mark.parametrize(
     ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
     [
-        (None, '000', True, False, ['100', '110']),
-        (None, '100', True, True, ['110', '80']),
-        (None, '105', True, True, ['110', '80']),
-        (None, '110', False, True, ['80', '90']),
-        (None, '115', False, True, ['80', '90']),
-        (None, '75', False, True, ['80', '90']),
-        (None, '80', False, True, ['90']),
-        (None, '85', False, True, ['90']),
-        (None, '90', False, True, []),
-        (None, '95', False, True, []),
-        ('95', None, False, True, ['80', '90']),
-        ('90', None, True, True, ['110', '80']),
-        ('85', None, True, True, ['110', '80']),
-        ('80', None, True, False, ['100', '110']),
-        ('75', None, True, False, ['100', '110']),
-        ('115', None, True, False, ['100', '110']),
-        ('110', None, True, False, ['100']),
-        ('105', None, True, False, ['100']),
-        ('100', None, True, False, []),
-        ('000', None, True, False, []),
+        (None, "000", True, False, ["100", "110"]),
+        (None, "100", True, True, ["110", "80"]),
+        (None, "105", True, True, ["110", "80"]),
+        (None, "110", False, True, ["80", "90"]),
+        (None, "115", False, True, ["80", "90"]),
+        (None, "75", False, True, ["80", "90"]),
+        (None, "80", False, True, ["90"]),
+        (None, "85", False, True, ["90"]),
+        (None, "90", False, True, []),
+        (None, "95", False, True, []),
+        ("95", None, False, True, ["80", "90"]),
+        ("90", None, True, True, ["110", "80"]),
+        ("85", None, True, True, ["110", "80"]),
+        ("80", None, True, False, ["100", "110"]),
+        ("75", None, True, False, ["100", "110"]),
+        ("115", None, True, False, ["100", "110"]),
+        ("110", None, True, False, ["100"]),
+        ("105", None, True, False, ["100"]),
+        ("100", None, True, False, []),
+        ("000", None, True, False, []),
     ],
 )
 def test_paginated_find_string_pk(

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -1,5 +1,7 @@
 import pytest
 
+from sqlalchemy_bind_manager._repository.common import Cursor
+
 
 def _test_models(model_class):
     return [
@@ -18,17 +20,18 @@ def _test_models(model_class):
         model_class(
             model_id=40,
             name="NoOne",
-        )
+        ),
     ]
-
 
 
 def test_paginated_find_page_length_after(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))
     results = repo.cursor_paginated_find(
-        order_by="model_id",
-        after=10,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=10,
+        ),
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -43,8 +46,11 @@ def test_paginated_find_page_length_before(repository_class, model_class, sa_man
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        order_by="model_id",
-        before=40,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=40,
+        ),
+        is_end_cursor=True,
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -52,24 +58,6 @@ def test_paginated_find_page_length_before(repository_class, model_class, sa_man
     assert results.items[1].name == "StillSomeoneElse"
     assert results.page_info.items_per_page == 2
     assert results.page_info.total_items == 4
-
-
-def test_paginated_find_must_use_either_after_or_before(
-    repository_class, model_class, sa_manager
-):
-    repo = repository_class(sa_manager.get_bind())
-    with pytest.raises(ValueError):
-        repo.cursor_paginated_find(
-            order_by="model_id",
-            after=1,
-            before=4,
-            items_per_page=2,
-        )
-    with pytest.raises(ValueError):
-        repo.cursor_paginated_find(
-            order_by="model_id",
-            items_per_page=2,
-        )
 
 
 def test_paginated_find_max_page_length_is_respected(
@@ -80,8 +68,10 @@ def test_paginated_find_max_page_length_is_respected(
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        order_by="model_id",
-        after=10,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=10,
+        ),
         items_per_page=50,
     )
     assert len(results.items) == 2
@@ -96,8 +86,10 @@ def test_paginated_find_after_last_item(repository_class, model_class, sa_manage
     repo.save_many(_test_models(model_class))
 
     results = repo.cursor_paginated_find(
-        order_by="model_id",
-        after=40,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=40,
+        ),
         items_per_page=2,
     )
 
@@ -106,45 +98,59 @@ def test_paginated_find_after_last_item(repository_class, model_class, sa_manage
     assert results.page_info.total_items == 4
 
 
-
-
-@pytest.mark.parametrize(["before", "after", "has_next_page", "has_previous_page", "returned_ids"], [
-    (None, 5, True, False, [10, 20]),
-    (None, 10, True, True, [20, 30]),
-    (None, 15, True, True, [20, 30]),
-    (None, 20, False, True, [30, 40]),
-    (None, 25, False, True, [30, 40]),
-    (None, 30, False, True, [40]),
-    (None, 35, False, True, [40]),
-    (None, 40, False, True, []),
-    (None, 45, False, True, []),
-    (45, None, False, True, [30, 40]),
-    (40, None, True, True, [20, 30]),
-    (35, None, True, True, [20, 30]),
-    (30, None, True, False, [10, 20]),
-    (25, None, True, False, [10, 20]),
-    (20, None, True, False, [10]),
-    (15, None, True, False, [10]),
-    (10, None, True, False, []),
-    (5, None, True, False, []),
-])
+@pytest.mark.parametrize(
+    ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
+    [
+        (None, 5, True, False, [10, 20]),
+        (None, 10, True, True, [20, 30]),
+        (None, 15, True, True, [20, 30]),
+        (None, 20, False, True, [30, 40]),
+        (None, 25, False, True, [30, 40]),
+        (None, 30, False, True, [40]),
+        (None, 35, False, True, [40]),
+        (None, 40, False, True, []),
+        (None, 45, False, True, []),
+        (45, None, False, True, [30, 40]),
+        (40, None, True, True, [20, 30]),
+        (35, None, True, True, [20, 30]),
+        (30, None, True, False, [10, 20]),
+        (25, None, True, False, [10, 20]),
+        (20, None, True, False, [10]),
+        (15, None, True, False, [10]),
+        (10, None, True, False, []),
+        (5, None, True, False, []),
+    ],
+)
 def test_paginated_find_previous_next_page(
-    repository_class, model_class, sa_manager, before, after, has_next_page, has_previous_page, returned_ids
+    repository_class,
+    model_class,
+    sa_manager,
+    before,
+    after,
+    has_next_page,
+    has_previous_page,
+    returned_ids,
 ):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))
 
     result = repo.cursor_paginated_find(
-        order_by="model_id",
-        before=before,
-        after=after,
+        reference_cursor=Cursor(
+            column="model_id",
+            value=after or before,
+        ),
+        is_end_cursor=bool(before),
         items_per_page=2,
     )
 
     assert len(returned_ids) == len(result.items)
     if len(returned_ids):
-        assert result.page_info.start_cursor == str(result.items[0].model_id)
-        assert result.page_info.end_cursor == str(result.items[-1].model_id)
+        assert result.page_info.start_cursor == repo.encode_cursor(
+            Cursor(value=result.items[0].model_id, column="model_id")
+        )
+        assert result.page_info.end_cursor == repo.encode_cursor(
+            Cursor(value=result.items[-1].model_id, column="model_id")
+        )
     for k, v in enumerate(returned_ids):
         assert result.items[k].model_id == v
     assert result.page_info.has_next_page == has_next_page

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sqlalchemy_bind_manager._repository.common import Cursor
+from sqlalchemy_bind_manager._repository.base_repository import Cursor
 
 
 def _test_models(model_class):

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -24,6 +24,34 @@ def _test_models(model_class):
     ]
 
 
+@pytest.mark.parametrize(["items_per_page", "expected_next_page"], [
+    [2, True],
+    [4, False],
+])
+def test_paginated_find_without_cursor(
+    repository_class, model_class, sa_manager, items_per_page, expected_next_page
+):
+    repo = repository_class(sa_manager.get_bind())
+    repo.save_many(_test_models(model_class))
+
+    results = repo.cursor_paginated_find(
+        items_per_page=items_per_page,
+    )
+    assert len(results.items) == items_per_page
+    assert results.items[0].name == "Someone"
+    assert results.items[1].name == "SomeoneElse"
+    assert results.page_info.items_per_page == items_per_page
+    assert results.page_info.total_items == 4
+    assert results.page_info.has_next_page is expected_next_page
+    assert results.page_info.has_previous_page is False
+    assert results.page_info.start_cursor == repo.encode_cursor(
+        Cursor(value=results.items[0].model_id, column="model_id")
+    )
+    assert results.page_info.end_cursor == repo.encode_cursor(
+        Cursor(value=results.items[-1].model_id, column="model_id")
+    )
+
+
 def test_paginated_find_page_length_after(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -94,7 +94,7 @@ def test_paginated_find_page_length_before(repository_class, model_class, sa_man
             column="model_id",
             value=110,
         ),
-        is_end_cursor=True,
+        is_before_cursor=True,
         items_per_page=2,
     )
     assert len(results.items) == 2
@@ -184,7 +184,7 @@ def test_paginated_find_previous_next_page(
             column="model_id",
             value=after or before,
         ),
-        is_end_cursor=bool(before),
+        is_before_cursor=bool(before),
         items_per_page=2,
     )
 
@@ -246,7 +246,7 @@ def test_paginated_find_string_pk(
             column="model_id",
             value=after or before,
         ),
-        is_end_cursor=bool(before),
+        is_before_cursor=bool(before),
         items_per_page=2,
     )
 

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -1,4 +1,4 @@
-from sqlalchemy_bind_manager import SortDirection
+import pytest
 
 
 def test_paginated_find_page_length(repository_class, model_class, sa_manager):
@@ -18,17 +18,24 @@ def test_paginated_find_page_length(repository_class, model_class, sa_manager):
         name="StillSomeoneElse",
     )
     repo.save(model3)
+    model4 = model_class(
+        model_id=4,
+        name="NoOne",
+    )
+    repo.save(model4)
 
     results = repo.cursor_paginated_find(
-        after=("model_id", 1), items_per_page=2
+        order_by="model_id",
+        after=1,
+        items_per_page=2,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.page is None
     assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.total_pages == 2
+    assert results.total_items == 4
+    assert results.has_next_page is True
+    assert results.has_previous_page is True
 
 
 def test_paginated_find_reverse_page_length(repository_class, model_class, sa_manager):
@@ -48,17 +55,42 @@ def test_paginated_find_reverse_page_length(repository_class, model_class, sa_ma
         name="StillSomeoneElse",
     )
     repo.save(model3)
+    model4 = model_class(
+        model_id=4,
+        name="NoOne",
+    )
+    repo.save(model4)
 
     results = repo.cursor_paginated_find(
-        after=("model_id", 3), items_per_page=2, direction=SortDirection.DESC
+        order_by="model_id",
+        before=4,
+        items_per_page=2,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
-    assert results.items[1].name == "Someone"
-    assert results.page is None
+    assert results.items[1].name == "StillSomeoneElse"
     assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.total_pages == 2
+    assert results.total_items == 4
+    assert results.has_next_page is True
+    assert results.has_previous_page is True
+
+
+def test_paginated_find_must_use_either_after_or_before(
+    repository_class, model_class, sa_manager
+):
+    repo = repository_class(sa_manager.get_bind())
+    with pytest.raises(ValueError):
+        repo.cursor_paginated_find(
+            order_by="model_id",
+            after=1,
+            before=4,
+            items_per_page=2,
+        )
+    with pytest.raises(ValueError):
+        repo.cursor_paginated_find(
+            order_by="model_id",
+            items_per_page=2,
+        )
 
 
 def test_paginated_find_max_page_length_is_respected(
@@ -80,15 +112,17 @@ def test_paginated_find_max_page_length_is_respected(
     repo.save(model3)
 
     results = repo.cursor_paginated_find(
-        after=("model_id", 1), items_per_page=50
+        order_by="model_id",
+        after=1,
+        items_per_page=50,
     )
     assert len(results.items) == 2
     assert results.items[0].name == "SomeoneElse"
     assert results.items[1].name == "StillSomeoneElse"
-    assert results.page is None
     assert results.items_per_page == 2
-    assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is False
+    assert results.has_previous_page is True
 
 
 def test_paginated_find_after_last_item(repository_class, model_class, sa_manager):
@@ -107,33 +141,13 @@ def test_paginated_find_after_last_item(repository_class, model_class, sa_manage
     repo.save(model3)
 
     results = repo.cursor_paginated_find(
-        after=("model_id", 3), items_per_page=2
+        order_by="model_id",
+        after=3,
+        items_per_page=2,
     )
+
     assert len(results.items) == 0
-    assert results.page is None
     assert results.items_per_page == 2
-    assert results.total_pages == 2
     assert results.total_items == 3
-
-
-def test_paginated_find_no_result_filters(repository_class, model_class, sa_manager):
-    repo = repository_class(sa_manager.get_bind())
-    model = model_class(
-        name="Someone",
-    )
-    repo.save(model)
-    model2 = model_class(
-        name="SomeoneElse",
-    )
-    repo.save(model2)
-    model3 = model_class(
-        name="StillSomeoneElse",
-    )
-    repo.save(model3)
-
-    results = repo.paginated_find(page=1, items_per_page=2, search_params={"name": "Goofy"})
-    assert len(results.items) == 0
-    assert results.page == 0
-    assert results.items_per_page == 2
-    assert results.total_pages == 0
-    assert results.total_items == 0
+    assert results.has_next_page is False
+    assert results.has_previous_page is True

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -145,6 +145,7 @@ def test_paginated_find_after_last_item(repository_class, model_class, sa_manage
     assert results.page_info.total_items == 4
 
 
+# Numeric order here is 80,90,100,110
 @pytest.mark.parametrize(
     ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
     [
@@ -180,6 +181,68 @@ def test_paginated_find_previous_next_page(
 ):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))
+
+    result = repo.cursor_paginated_find(
+        reference_cursor=Cursor(
+            column="model_id",
+            value=after or before,
+        ),
+        is_end_cursor=bool(before),
+        items_per_page=2,
+    )
+
+    assert len(returned_ids) == len(result.items)
+    if len(returned_ids):
+        assert result.page_info.start_cursor == repo.encode_cursor(
+            Cursor(value=result.items[0].model_id, column="model_id")
+        )
+        assert result.page_info.end_cursor == repo.encode_cursor(
+            Cursor(value=result.items[-1].model_id, column="model_id")
+        )
+    for k, v in enumerate(returned_ids):
+        assert result.items[k].model_id == v
+    assert result.page_info.has_next_page == has_next_page
+    assert result.page_info.has_previous_page == has_previous_page
+
+
+# Lexigraphic order here is 100,110,80,90
+@pytest.mark.parametrize(
+    ["before", "after", "has_next_page", "has_previous_page", "returned_ids"],
+    [
+        (None, '000', True, False, ['100', '110']),
+        (None, '100', True, True, ['110', '80']),
+        (None, '105', True, True, ['110', '80']),
+        (None, '110', False, True, ['80', '90']),
+        (None, '115', False, True, ['80', '90']),
+        (None, '75', False, True, ['80', '90']),
+        (None, '80', False, True, ['90']),
+        (None, '85', False, True, ['90']),
+        (None, '90', False, True, []),
+        (None, '95', False, True, []),
+        ('95', None, False, True, ['80', '90']),
+        ('90', None, True, True, ['110', '80']),
+        ('85', None, True, True, ['110', '80']),
+        ('80', None, True, False, ['100', '110']),
+        ('75', None, True, False, ['100', '110']),
+        ('115', None, True, False, ['100', '110']),
+        ('110', None, True, False, ['100']),
+        ('105', None, True, False, ['100']),
+        ('100', None, True, False, []),
+        ('000', None, True, False, []),
+    ],
+)
+def test_paginated_find_string_pk(
+    repository_class_string_pk,
+    model_class_string_pk,
+    sa_manager,
+    before,
+    after,
+    has_next_page,
+    has_previous_page,
+    returned_ids,
+):
+    repo = repository_class_string_pk(sa_manager.get_bind())
+    repo.save_many(_test_models(model_class_string_pk))
 
     result = repo.cursor_paginated_find(
         reference_cursor=Cursor(

--- a/tests/repository/sync/test_cursor_pagination.py
+++ b/tests/repository/sync/test_cursor_pagination.py
@@ -52,6 +52,23 @@ def test_paginated_find_without_cursor(
     )
 
 
+def test_paginated_find_accepts_encoded_cursors(repository_class, model_class, sa_manager):
+    repo = repository_class(sa_manager.get_bind())
+    repo.save_many(_test_models(model_class))
+    results = repo.cursor_paginated_find(
+        reference_cursor=repo.encode_cursor(Cursor(
+            column="model_id",
+            value=80,
+        )),
+        items_per_page=2,
+    )
+    assert len(results.items) == 2
+    assert results.items[0].name == "SomeoneElse"
+    assert results.items[1].name == "StillSomeoneElse"
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 4
+
+
 def test_paginated_find_page_length_after(repository_class, model_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
     repo.save_many(_test_models(model_class))

--- a/tests/repository/sync/test_find.py
+++ b/tests/repository/sync/test_find.py
@@ -1,7 +1,7 @@
 import pytest
 
-from sqlalchemy_bind_manager import SortDirection
 from sqlalchemy_bind_manager.exceptions import UnmappedProperty
+from sqlalchemy_bind_manager.repository import SortDirection
 
 
 def test_find(repository_class, model_class, sa_manager):

--- a/tests/repository/sync/test_lifecycle.py
+++ b/tests/repository/sync/test_lifecycle.py
@@ -2,12 +2,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sqlalchemy_bind_manager import SQLAlchemyRepository
 from sqlalchemy_bind_manager.exceptions import (
     InvalidConfig,
     InvalidModel,
     UnsupportedBind,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyRepository
 
 
 def test_repository_fails_if_not_sync_bind(sync_async_sa_manager, model_class):

--- a/tests/repository/sync/test_pagination.py
+++ b/tests/repository/sync/test_pagination.py
@@ -17,12 +17,12 @@ def test_paginated_find_page_length(repository_class, model_class, sa_manager):
     assert len(results.items) == 2
     assert results.items[0].name == "Someone"
     assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
-    assert results.items_per_page == 2
-    assert results.total_items == 3
-    assert results.total_pages == 2
-    assert results.has_next_page is True
-    assert results.has_previous_page is False
+    assert results.page_info.page == 1
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.total_pages == 2
+    assert results.page_info.has_next_page is True
+    assert results.page_info.has_previous_page is False
 
 
 def test_paginated_find_max_page_length_is_respected(
@@ -47,12 +47,12 @@ def test_paginated_find_max_page_length_is_respected(
     assert len(results.items) == 2
     assert results.items[0].name == "Someone"
     assert results.items[1].name == "SomeoneElse"
-    assert results.page == 1
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-    assert results.has_next_page is True
-    assert results.has_previous_page is False
+    assert results.page_info.page == 1
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.has_next_page is True
+    assert results.page_info.has_previous_page is False
 
 
 def test_paginated_find_last_page(repository_class, model_class, sa_manager):
@@ -73,12 +73,12 @@ def test_paginated_find_last_page(repository_class, model_class, sa_manager):
     results = repo.paginated_find(page=2, items_per_page=2)
     assert len(results.items) == 1
     assert results.items[0].name == "StillSomeoneElse"
-    assert results.page == 2
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-    assert results.has_next_page is False
-    assert results.has_previous_page is True
+    assert results.page_info.page == 2
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.has_next_page is False
+    assert results.page_info.has_previous_page is True
 
 
 def test_paginated_find_after_last_page(repository_class, model_class, sa_manager):
@@ -98,12 +98,12 @@ def test_paginated_find_after_last_page(repository_class, model_class, sa_manage
 
     results = repo.paginated_find(page=4, items_per_page=2)
     assert len(results.items) == 0
-    assert results.page == 0
-    assert results.items_per_page == 2
-    assert results.total_pages == 2
-    assert results.total_items == 3
-    assert results.has_next_page is False
-    assert results.has_previous_page is False
+    assert results.page_info.page == 0
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 2
+    assert results.page_info.total_items == 3
+    assert results.page_info.has_next_page is False
+    assert results.page_info.has_previous_page is False
 
 
 def test_paginated_find_no_result_filters(repository_class, model_class, sa_manager):
@@ -125,9 +125,9 @@ def test_paginated_find_no_result_filters(repository_class, model_class, sa_mana
         page=1, items_per_page=2, search_params={"name": "Goofy"}
     )
     assert len(results.items) == 0
-    assert results.page == 0
-    assert results.items_per_page == 2
-    assert results.total_pages == 0
-    assert results.total_items == 0
-    assert results.has_next_page is False
-    assert results.has_previous_page is False
+    assert results.page_info.page == 0
+    assert results.page_info.items_per_page == 2
+    assert results.page_info.total_pages == 0
+    assert results.page_info.total_items == 0
+    assert results.page_info.has_next_page is False
+    assert results.page_info.has_previous_page is False

--- a/tests/repository/sync/test_pagination.py
+++ b/tests/repository/sync/test_pagination.py
@@ -21,6 +21,8 @@ def test_paginated_find_page_length(repository_class, model_class, sa_manager):
     assert results.items_per_page == 2
     assert results.total_items == 3
     assert results.total_pages == 2
+    assert results.has_next_page is True
+    assert results.has_previous_page is False
 
 
 def test_paginated_find_max_page_length_is_respected(
@@ -49,6 +51,8 @@ def test_paginated_find_max_page_length_is_respected(
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is True
+    assert results.has_previous_page is False
 
 
 def test_paginated_find_last_page(repository_class, model_class, sa_manager):
@@ -73,6 +77,8 @@ def test_paginated_find_last_page(repository_class, model_class, sa_manager):
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is False
+    assert results.has_previous_page is True
 
 
 def test_paginated_find_after_last_page(repository_class, model_class, sa_manager):
@@ -96,6 +102,8 @@ def test_paginated_find_after_last_page(repository_class, model_class, sa_manage
     assert results.items_per_page == 2
     assert results.total_pages == 2
     assert results.total_items == 3
+    assert results.has_next_page is False
+    assert results.has_previous_page is False
 
 
 def test_paginated_find_no_result_filters(repository_class, model_class, sa_manager):
@@ -113,9 +121,13 @@ def test_paginated_find_no_result_filters(repository_class, model_class, sa_mana
     )
     repo.save(model3)
 
-    results = repo.paginated_find(page=1, items_per_page=2, search_params={"name": "Goofy"})
+    results = repo.paginated_find(
+        page=1, items_per_page=2, search_params={"name": "Goofy"}
+    )
     assert len(results.items) == 0
     assert results.page == 0
     assert results.items_per_page == 2
     assert results.total_pages == 0
     assert results.total_items == 0
+    assert results.has_next_page is False
+    assert results.has_previous_page is False

--- a/tests/repository/test_common.py
+++ b/tests/repository/test_common.py
@@ -1,0 +1,9 @@
+from sqlalchemy_bind_manager._repository import CursorReference
+
+
+def test_cursor_reference_doesnt_coerce_values():
+    r = CursorReference(
+        column="column_name",
+        value=10,
+    )
+    assert isinstance(r.value, int)

--- a/tests/repository/test_composite_pk.py
+++ b/tests/repository/test_composite_pk.py
@@ -1,0 +1,59 @@
+import os
+from typing import Type
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import Column, String, Integer
+from sqlalchemy.orm import clear_mappers
+
+from sqlalchemy_bind_manager import SQLAlchemyRepository, SQLAlchemyBindManager, SQLAlchemyConfig
+
+
+@pytest.fixture
+def sa_manager() -> SQLAlchemyBindManager:
+    test_db_path = f"./{uuid4()}.db"
+    config = SQLAlchemyConfig(
+        engine_url=f"sqlite:///{test_db_path}",
+        engine_options=dict(connect_args={"check_same_thread": False}),
+        session_options=dict(expire_on_commit=False),
+    )
+    yield SQLAlchemyBindManager(config)
+    try:
+        os.unlink(test_db_path)
+    except FileNotFoundError:
+        pass
+    clear_mappers()
+
+
+@pytest.fixture
+def model_class_composite_pk(sa_manager) -> Type:
+    default_bind = sa_manager.get_bind()
+
+    class MyModel(default_bind.model_declarative_base):
+        __tablename__ = "mymodel"
+        # required in order to access columns with server defaults
+        # or SQL expression defaults, subsequent to a flush, without
+        # triggering an expired load
+        __mapper_args__ = {"eager_defaults": True}
+
+        model_id = Column(Integer, primary_key=True)
+        model_other_id = Column(Integer, primary_key=True)
+        name = Column(String)
+
+    default_bind.registry_mapper.metadata.create_all(default_bind.engine)
+
+    return MyModel
+
+
+@pytest.fixture
+def repository_class(model_class_composite_pk) -> Type[SQLAlchemyRepository]:
+    class MyRepository(SQLAlchemyRepository[model_class_composite_pk]):
+        _model = model_class_composite_pk
+
+    return MyRepository
+
+
+def test_cannot_use_models_with_composite_pk(repository_class, sa_manager):
+    repo = repository_class(sa_manager.get_bind())
+    with pytest.raises(NotImplementedError):
+        repo._model_pk()

--- a/tests/repository/test_composite_pk.py
+++ b/tests/repository/test_composite_pk.py
@@ -3,10 +3,14 @@ from typing import Type
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import Column, String, Integer
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import clear_mappers
 
-from sqlalchemy_bind_manager import SQLAlchemyRepository, SQLAlchemyBindManager, SQLAlchemyConfig
+from sqlalchemy_bind_manager import (
+    SQLAlchemyBindManager,
+    SQLAlchemyConfig,
+    SQLAlchemyRepository,
+)
 
 
 @pytest.fixture

--- a/tests/repository/test_composite_pk.py
+++ b/tests/repository/test_composite_pk.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import clear_mappers
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyConfig,
-    SQLAlchemyRepository,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyRepository
 
 
 @pytest.fixture

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,9 +1,12 @@
 from inspect import signature
 
-from sqlalchemy_bind_manager import SQLAlchemyAsyncRepository, SQLAlchemyRepository
 from sqlalchemy_bind_manager.protocols import (
     SQLAlchemyAsyncRepositoryInterface,
     SQLAlchemyRepositoryInterface,
+)
+from sqlalchemy_bind_manager.repository import (
+    SQLAlchemyAsyncRepository,
+    SQLAlchemyRepository,
 )
 
 

--- a/tests/transaction_handler/async_/conftest.py
+++ b/tests/transaction_handler/async_/conftest.py
@@ -8,9 +8,9 @@ from sqlalchemy.orm import clear_mappers
 
 from sqlalchemy_bind_manager import (
     SQLAlchemyAsyncConfig,
-    SQLAlchemyAsyncRepository,
     SQLAlchemyBindManager,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyAsyncRepository
 
 
 @pytest.fixture

--- a/tests/transaction_handler/sync/conftest.py
+++ b/tests/transaction_handler/sync/conftest.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import clear_mappers
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyConfig,
-    SQLAlchemyRepository,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyRepository
 
 
 @pytest.fixture

--- a/tests/unit_of_work/async_/conftest.py
+++ b/tests/unit_of_work/async_/conftest.py
@@ -8,9 +8,9 @@ from sqlalchemy.orm import clear_mappers
 
 from sqlalchemy_bind_manager import (
     SQLAlchemyAsyncConfig,
-    SQLAlchemyAsyncRepository,
     SQLAlchemyBindManager,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyAsyncRepository
 
 
 @pytest.fixture

--- a/tests/unit_of_work/sync/conftest.py
+++ b/tests/unit_of_work/sync/conftest.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import clear_mappers
 from sqlalchemy_bind_manager import (
     SQLAlchemyBindManager,
     SQLAlchemyConfig,
-    SQLAlchemyRepository,
 )
+from sqlalchemy_bind_manager.repository import SQLAlchemyRepository
 
 
 @pytest.fixture


### PR DESCRIPTION
Adds cursor-based pagination capability to support GraphQL-Relay style. Single column ordering only supported.

# Breaking changes
* All repository and unit of work related resources are now available in `sqlalchemy_bind_manager.repository` module and not anymore in `sqlalchemy_bind_manager` base module
* Pagination information for `PaginatedResult` are now grouped in a nested `PageInfo` object in the `PaginatedResult.page_info` property.
* `per_page` and `items_per_page` occurrences have been consolidates as `items_per_page`

# Non-breaking changes
* `BaseRepository` moved to its own module
* Presenter classes added to produce `PaginatedResult` and `CursorPaginatedResult`
* Default `paginated_find` to page 1
