### PR TITLE
Add repository methods for collections of models

### DIFF
--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -97,6 +97,11 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         async with self._get_session() as session:
             await session.delete(instance)
 
+    async def delete_many(self, instances: Iterable[MODEL]) -> None:
+        async with self._get_session() as session:
+            for instance in instances:
+                await session.delete(instance)
+
     async def find(
         self,
         search_params: Union[None, Mapping[str, Any]] = None,

--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -93,17 +93,9 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         async with self._get_session(commit=False) as session:
             return [x for x in (await session.execute(stmt)).scalars()]
 
-    async def delete(
-        self,
-        entity: Union[MODEL, PRIMARY_KEY],
-    ) -> None:
-        # TODO: delete without loading the model
-        if isinstance(entity, self._model):
-            obj = entity
-        else:
-            obj = await self.get(entity)  # type: ignore
+    async def delete(self, instance: MODEL) -> None:
         async with self._get_session() as session:
-            await session.delete(obj)
+            await session.delete(instance)
 
     async def find(
         self,

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -86,6 +86,11 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         with self._get_session() as session:
             session.delete(instance)
 
+    def delete_many(self, instances: Iterable[MODEL]) -> None:
+        with self._get_session() as session:
+            for model in instances:
+                session.delete(model)
+
     def find(
         self,
         search_params: Union[None, Mapping[str, Any]] = None,

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -82,14 +82,9 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         with self._get_session(commit=False) as session:
             return [x for x in session.execute(stmt).scalars()]
 
-    def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:
-        # TODO: delete without loading the model
-        if isinstance(entity, self._model):
-            obj = entity
-        else:
-            obj = self.get(entity)  # type: ignore
+    def delete(self, instance: MODEL) -> None:
         with self._get_session() as session:
-            session.delete(obj)
+            session.delete(instance)
 
     def find(
         self,

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -59,11 +59,10 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
         """
         ...
 
-    async def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:
+    async def delete(self, instance: MODEL) -> None:
         """Deletes a model.
 
-        :param entity: The model instance or the primary key
-        :type entity: Union[MODEL, PRIMARY_KEY]
+        :param instance: The model instance or the primary key
         """
         ...
 
@@ -197,7 +196,6 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
         :return: A model instance
         :raises ModelNotFound: No model has been found using the primary key
         """
-        # TODO: implement get_many()
         ...
 
     def get_many(self, identifiers: Iterable[PRIMARY_KEY]) -> List[MODEL]:
@@ -210,11 +208,10 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
         """
         ...
 
-    def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:
+    def delete(self, instance: MODEL) -> None:
         """Deletes a model.
 
-        :param entity: The model instance or the primary key
-        :type entity: Union[MODEL, PRIMARY_KEY]
+        :param instance: The model instance or the primary key
         """
         ...
 

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -62,7 +62,14 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
     async def delete(self, instance: MODEL) -> None:
         """Deletes a model.
 
-        :param instance: The model instance or the primary key
+        :param instance: The model instance
+        """
+        ...
+
+    async def delete_many(self, instances: Iterable[MODEL]) -> None:
+        """Deletes a collection of models in a single transaction.
+
+        :param instances: The model instances
         """
         ...
 
@@ -211,7 +218,14 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
     def delete(self, instance: MODEL) -> None:
         """Deletes a model.
 
-        :param instance: The model instance or the primary key
+        :param instance: The model instance
+        """
+        ...
+
+    async def delete_many(self, instances: Iterable[MODEL]) -> None:
+        """Deletes a collection of models in a single transaction.
+
+        :param instances: The model instances
         """
         ...
 

--- a/sqlalchemy_bind_manager/protocols.py
+++ b/sqlalchemy_bind_manager/protocols.py
@@ -47,7 +47,16 @@ class SQLAlchemyAsyncRepositoryInterface(Protocol[MODEL]):
         :return: A model instance
         :raises ModelNotFound: No model has been found using the primary key
         """
-        # TODO: implement get_many()
+        ...
+
+    async def get_many(self, identifiers: Iterable[PRIMARY_KEY]) -> List[MODEL]:
+        """Get a list of models by primary keys.
+
+        :param identifiers: A list of primary keys
+        :type identifiers: List
+        :return: A list of models
+        :rtype: List
+        """
         ...
 
     async def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:
@@ -189,6 +198,16 @@ class SQLAlchemyRepositoryInterface(Protocol[MODEL]):
         :raises ModelNotFound: No model has been found using the primary key
         """
         # TODO: implement get_many()
+        ...
+
+    def get_many(self, identifiers: Iterable[PRIMARY_KEY]) -> List[MODEL]:
+        """Get a list of models by primary keys.
+
+        :param identifiers: A list of primary keys
+        :type identifiers: List
+        :return: A list of models
+        :rtype: List
+        """
         ...
 
     def delete(self, entity: Union[MODEL, PRIMARY_KEY]) -> None:

--- a/tests/repository/async_/test_delete.py
+++ b/tests/repository/async_/test_delete.py
@@ -1,26 +1,5 @@
 import pytest
-
-
-async def test_can_delete_by_pk(repository_class, model_class, sa_manager):
-    model = model_class(
-        model_id=1,
-        name="Someone",
-    )
-    model2 = model_class(
-        model_id=2,
-        name="SomeoneElse",
-    )
-    repo = repository_class(sa_manager.get_bind())
-    await repo.save_many({model, model2})
-
-    results = [x for x in await repo.find()]
-    assert len(results) == 2
-
-    await repo.delete(1)
-    results = [x for x in await repo.find()]
-    assert len(results) == 1
-    assert results[0].model_id == 2
-    assert results[0].name == "SomeoneElse"
+from sqlalchemy import select
 
 
 async def test_can_delete_by_instance(repository_class, model_class, sa_manager):
@@ -55,3 +34,26 @@ async def test_delete_inexistent_raises_exception(
 
     with pytest.raises(Exception):
         await repo.delete(4)
+
+
+async def test_relationships_are_respected(
+    related_repository_class, related_model_classes, sa_manager
+):
+    parent = related_model_classes[0](
+        name="A Parent",
+    )
+    child = related_model_classes[1](name="A Child")
+    child2 = related_model_classes[1](name="Another Child")
+    parent.children.append(child)
+    parent.children.append(child2)
+    repo = related_repository_class(sa_manager.get_bind())
+    await repo.save(parent)
+
+    retrieved_parent = await repo.get(parent.parent_model_id)
+    assert len(retrieved_parent.children) == 2
+
+    await repo.delete(retrieved_parent)
+
+    async with repo._get_session() as session:
+        result = [x for x in (await session.execute(select(related_model_classes[1]))).scalars()]
+        assert len(result) == 0

--- a/tests/repository/async_/test_delete_many.py
+++ b/tests/repository/async_/test_delete_many.py
@@ -17,7 +17,7 @@ async def test_can_delete_by_instance(repository_class, model_class, sa_manager)
     results = [x for x in await repo.find()]
     assert len(results) == 2
 
-    await repo.delete(model)
+    await repo.delete_many([model])
     results = [x for x in await repo.find()]
     assert len(results) == 1
     assert results[0].model_id == 2
@@ -33,14 +33,16 @@ async def test_delete_inexistent_raises_exception(
     assert len(results) == 0
 
     with pytest.raises(Exception):
-        await repo.delete(4)
+        await repo.delete_many([4])
 
     with pytest.raises(Exception):
-        await repo.delete(
-            model_class(
-                model_id=823,
-                name="Someone",
-            )
+        await repo.delete_many(
+            [
+                model_class(
+                    model_id=823,
+                    name="Someone",
+                )
+            ]
         )
 
 
@@ -60,7 +62,7 @@ async def test_relationships_are_respected(
     retrieved_parent = await repo.get(parent.parent_model_id)
     assert len(retrieved_parent.children) == 2
 
-    await repo.delete(retrieved_parent)
+    await repo.delete_many([retrieved_parent])
 
     async with repo._get_session() as session:
         result = [

--- a/tests/repository/async_/test_get.py
+++ b/tests/repository/async_/test_get.py
@@ -19,6 +19,39 @@ async def test_get_returns_model(repository_class, model_class, sa_manager):
     assert isinstance(result, model_class)
 
 
+async def test_get_many_returns_models(repository_class, model_class, sa_manager):
+    model = model_class(
+        model_id=1,
+        name="Someone",
+    )
+    model2 = model_class(
+        model_id=2,
+        name="SomeoneElse",
+    )
+    model3 = model_class(
+        model_id=3,
+        name="StillSomeoneElse",
+    )
+    repo = repository_class(sa_manager.get_bind())
+    await repo.save_many({model, model2, model3})
+
+    result = await repo.get_many([1, 2])
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0].model_id == 1
+    assert result[1].model_id == 2
+
+
+async def test_get_many_returns_empty_list_if_nothing_found(
+    repository_class, model_class, sa_manager
+):
+    repo = repository_class(sa_manager.get_bind())
+
+    result = await repo.get_many([1, 2])
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
 async def test_get_raises_exception_if_not_found(repository_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
 

--- a/tests/repository/sync/test_delete.py
+++ b/tests/repository/sync/test_delete.py
@@ -1,5 +1,4 @@
 import pytest
-
 from sqlalchemy import select
 
 
@@ -34,6 +33,14 @@ def test_delete_inexistent_raises_exception(repository_class, model_class, sa_ma
     with pytest.raises(Exception):
         repo.delete(4)
 
+    with pytest.raises(Exception):
+        repo.delete(
+            model_class(
+                model_id=823,
+                name="Someone",
+            )
+        )
+
 
 def test_relationships_are_respected(
     related_repository_class, related_model_classes, sa_manager
@@ -54,5 +61,7 @@ def test_relationships_are_respected(
     repo.delete(retrieved_parent)
 
     with repo._get_session() as session:
-        result = [x for x in session.execute(select(related_model_classes[1])).scalars()]
+        result = [
+            x for x in session.execute(select(related_model_classes[1])).scalars()
+        ]
         assert len(result) == 0

--- a/tests/repository/sync/test_delete.py
+++ b/tests/repository/sync/test_delete.py
@@ -1,26 +1,6 @@
 import pytest
 
-
-def test_can_delete_by_pk(repository_class, model_class, sa_manager):
-    model = model_class(
-        model_id=1,
-        name="Someone",
-    )
-    model2 = model_class(
-        model_id=2,
-        name="SomeoneElse",
-    )
-    repo = repository_class(sa_manager.get_bind())
-    repo.save_many({model, model2})
-
-    results = [x for x in repo.find()]
-    assert len(results) == 2
-
-    repo.delete(1)
-    results = [x for x in repo.find()]
-    assert len(results) == 1
-    assert results[0].model_id == 2
-    assert results[0].name == "SomeoneElse"
+from sqlalchemy import select
 
 
 def test_can_delete_by_instance(repository_class, model_class, sa_manager):
@@ -53,3 +33,26 @@ def test_delete_inexistent_raises_exception(repository_class, model_class, sa_ma
 
     with pytest.raises(Exception):
         repo.delete(4)
+
+
+def test_relationships_are_respected(
+    related_repository_class, related_model_classes, sa_manager
+):
+    parent = related_model_classes[0](
+        name="A Parent",
+    )
+    child = related_model_classes[1](name="A Child")
+    child2 = related_model_classes[1](name="Another Child")
+    parent.children.append(child)
+    parent.children.append(child2)
+    repo = related_repository_class(sa_manager.get_bind())
+    repo.save(parent)
+
+    retrieved_parent = repo.get(parent.parent_model_id)
+    assert len(retrieved_parent.children) == 2
+
+    repo.delete(retrieved_parent)
+
+    with repo._get_session() as session:
+        result = [x for x in session.execute(select(related_model_classes[1])).scalars()]
+        assert len(result) == 0

--- a/tests/repository/sync/test_get.py
+++ b/tests/repository/sync/test_get.py
@@ -19,6 +19,39 @@ def test_get_returns_model(repository_class, model_class, sa_manager):
     assert isinstance(result, model_class)
 
 
+def test_get_many_returns_models(repository_class, model_class, sa_manager):
+    model = model_class(
+        model_id=1,
+        name="Someone",
+    )
+    model2 = model_class(
+        model_id=2,
+        name="SomeoneElse",
+    )
+    model3 = model_class(
+        model_id=3,
+        name="StillSomeoneElse",
+    )
+    repo = repository_class(sa_manager.get_bind())
+    repo.save_many({model, model2, model3})
+
+    result = repo.get_many([1, 2])
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0].model_id == 1
+    assert result[1].model_id == 2
+
+
+def test_get_many_returns_empty_list_if_nothing_found(
+    repository_class, model_class, sa_manager
+):
+    repo = repository_class(sa_manager.get_bind())
+
+    result = repo.get_many([1, 2])
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
 def test_get_raises_exception_if_not_found(repository_class, sa_manager):
     repo = repository_class(sa_manager.get_bind())
 


### PR DESCRIPTION
# Breaking changes

* deleting by primary key support has been dropped in `delete` method:  It was necessary loading the model from the database anyway to handle correctly model relationships. This approach was neither performant, nor scalable.

# New features

* Added `get_many` method to get a collection of models by primary key
* Added `delete_many` to delete a collection of models in a single transaction
