### PR TITLE
Fail operations on models not belonging to repository

### DIFF
--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -66,6 +66,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             yield self._external_session
 
     async def save(self, instance: MODEL) -> MODEL:
+        self._fail_if_invalid_models([instance])
         async with self._get_session() as session:
             session.add(instance)
         return instance
@@ -74,6 +75,7 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
         self,
         instances: Iterable[MODEL],
     ) -> Iterable[MODEL]:
+        self._fail_if_invalid_models(instances)
         async with self._get_session() as session:
             session.add_all(instances)
         return instances
@@ -94,10 +96,12 @@ class SQLAlchemyAsyncRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             return [x for x in (await session.execute(stmt)).scalars()]
 
     async def delete(self, instance: MODEL) -> None:
+        self._fail_if_invalid_models([instance])
         async with self._get_session() as session:
             await session.delete(instance)
 
     async def delete_many(self, instances: Iterable[MODEL]) -> None:
+        self._fail_if_invalid_models(instances)
         async with self._get_session() as session:
             for instance in instances:
                 await session.delete(instance)

--- a/sqlalchemy_bind_manager/_repository/base_repository.py
+++ b/sqlalchemy_bind_manager/_repository/base_repository.py
@@ -318,3 +318,7 @@ class BaseRepository(Generic[MODEL], ABC):
             raise NotImplementedError("Composite primary keys are not supported.")
 
         return primary_keys[0].name
+
+    def _fail_if_invalid_models(self, objects: Iterable[MODEL]) -> None:
+        if [x for x in objects if not isinstance(x, self._model)]:
+            raise InvalidModel("Cannot handle models not belonging to this repository")

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -58,11 +58,13 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             yield self._external_session
 
     def save(self, instance: MODEL) -> MODEL:
+        self._fail_if_invalid_models([instance])
         with self._get_session() as session:
             session.add(instance)
         return instance
 
     def save_many(self, instances: Iterable[MODEL]) -> Iterable[MODEL]:
+        self._fail_if_invalid_models(instances)
         with self._get_session() as session:
             session.add_all(instances)
         return instances
@@ -83,10 +85,12 @@ class SQLAlchemyRepository(Generic[MODEL], BaseRepository[MODEL], ABC):
             return [x for x in session.execute(stmt).scalars()]
 
     def delete(self, instance: MODEL) -> None:
+        self._fail_if_invalid_models([instance])
         with self._get_session() as session:
             session.delete(instance)
 
     def delete_many(self, instances: Iterable[MODEL]) -> None:
+        self._fail_if_invalid_models(instances)
         with self._get_session() as session:
             for model in instances:
                 session.delete(model)

--- a/tests/repository/test_model_class_checks.py
+++ b/tests/repository/test_model_class_checks.py
@@ -1,0 +1,23 @@
+import pytest
+
+from sqlalchemy_bind_manager.exceptions import InvalidModel
+
+
+async def test_fails_when_saving_models_not_belonging_to_repository(
+    repository_class, model_classes, sa_bind, sync_async_wrapper
+):
+    repo = repository_class(bind=sa_bind, model_class=model_classes[0])
+
+    invalid_model = model_classes[1](name="A Child")
+
+    with pytest.raises(InvalidModel):
+        await sync_async_wrapper(repo.save(invalid_model))
+
+    with pytest.raises(InvalidModel):
+        await sync_async_wrapper(repo.save_many([invalid_model]))
+
+    with pytest.raises(InvalidModel):
+        await sync_async_wrapper(repo.delete(invalid_model))
+
+    with pytest.raises(InvalidModel):
+        await sync_async_wrapper(repo.delete_many([invalid_model]))


### PR DESCRIPTION
Persisting a model not belonging to the repository is not allowed, to avoid potential undesired behaviour.

Typing should already raise an alert but repositories for other models could have custom logic, therefore strict checks are a nice protection.