### PR TITLE
Add UUID to PRIMARY_KEY type union

### DIFF
--- a/.github/workflows/python-code-style.yml
+++ b/.github/workflows/python-code-style.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry
+        python -m pip install poetry poetry-plugin-export
         poetry config virtualenvs.create false
         poetry install --no-root --with dev
     - name: Check code style with black

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry tox
+        python -m pip install poetry tox poetry-plugin-export
         make poetry-export
     - name: Lint with ruff
       run: make lint

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry
+        python -m pip install poetry poetry-plugin-export
         poetry config virtualenvs.create false
         poetry install --no-root --with dev
     - name: Test & publish code coverage

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry
+        python -m pip install poetry poetry-plugin-export
         poetry config virtualenvs.create false
         poetry install --no-root --with dev
     - name: Test with pytest

--- a/.github/workflows/python-typing.yml
+++ b/.github/workflows/python-typing.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry tox
+        python -m pip install poetry tox poetry-plugin-export
         make poetry-export
     - name: Check typing
       run: make typing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry poetry-dynamic-versioning
+          python -m pip install poetry poetry-dynamic-versioning poetry-plugin-export
 
       - name: Build package
         run: |

--- a/sqlalchemy_bind_manager/_bind_manager.py
+++ b/sqlalchemy_bind_manager/_bind_manager.py
@@ -90,7 +90,7 @@ class SQLAlchemyBindManager:
     def __init_bind(self, name: str, config: SQLAlchemyConfig):
         if not isinstance(config, SQLAlchemyConfig):
             raise InvalidConfigError(
-                f"Config for bind `{name}` is not a SQLAlchemyConfig" f"object"
+                f"Config for bind `{name}` is not a SQLAlchemyConfig object"
             )
 
         engine_options: dict = config.engine_options or {}

--- a/sqlalchemy_bind_manager/_repository/common.py
+++ b/sqlalchemy_bind_manager/_repository/common.py
@@ -19,11 +19,12 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from typing import Generic, List, TypeVar, Union
+from uuid import UUID
 
 from pydantic import BaseModel, StrictInt, StrictStr
 
 MODEL = TypeVar("MODEL")
-PRIMARY_KEY = Union[str, int, tuple, dict]
+PRIMARY_KEY = Union[str, int, tuple, dict, UUID]
 
 
 class PageInfo(BaseModel):


### PR DESCRIPTION
Include UUID as a valid type for PRIMARY_KEY to support use cases requiring UUIDs. This ensures broader compatibility and type safety in key definitions.