### PR TITLE
Remove unused repository interface mixins from classes

### DIFF
--- a/sqlalchemy_bind_manager/_repository/async_.py
+++ b/sqlalchemy_bind_manager/_repository/async_.py
@@ -38,7 +38,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .._bind_manager import SQLAlchemyAsyncBind
 from .._session_handler import AsyncSessionHandler
 from ..exceptions import InvalidConfigError, ModelNotFoundError
-from .abstract import SQLAlchemyAsyncRepositoryInterface
 from .base_repository import (
     BaseRepository,
 )
@@ -55,7 +54,6 @@ from .result_presenters import CursorPaginatedResultPresenter, PaginatedResultPr
 class SQLAlchemyAsyncRepository(
     Generic[MODEL],
     BaseRepository[MODEL],
-    SQLAlchemyAsyncRepositoryInterface[MODEL],
 ):
     _session_handler: AsyncSessionHandler
     _external_session: Union[AsyncSession, None]

--- a/sqlalchemy_bind_manager/_repository/sync.py
+++ b/sqlalchemy_bind_manager/_repository/sync.py
@@ -38,7 +38,6 @@ from sqlalchemy.orm import Session
 from .._bind_manager import SQLAlchemyBind
 from .._session_handler import SessionHandler
 from ..exceptions import InvalidConfigError, ModelNotFoundError
-from .abstract import SQLAlchemyRepositoryInterface
 from .base_repository import (
     BaseRepository,
 )
@@ -55,7 +54,6 @@ from .result_presenters import CursorPaginatedResultPresenter, PaginatedResultPr
 class SQLAlchemyRepository(
     Generic[MODEL],
     BaseRepository[MODEL],
-    SQLAlchemyRepositoryInterface[MODEL],
 ):
     _session_handler: SessionHandler
     _external_session: Union[Session, None]


### PR DESCRIPTION
Eliminated `SQLAlchemyRepositoryInterface` and `SQLAlchemyAsyncRepositoryInterface` from their respective classes as they were no longer in use. This reduces unnecessary complexity and improves code maintainability.