### PR TITLE
Fix invalid Renovate packageRules matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,9 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchPackagePatterns": [
-        "*"
+      "matchPackageNames": [
+        "!python"
       ],
-      "excludePackageNames": ["python"],
       "matchUpdateTypes": [
         "minor",
         "patch"


### PR DESCRIPTION
Closes: https://github.com/febus982/sqlalchemy-bind-manager/issues/93

Renovate is currently refusing to open PRs on this repo:

> `packageRules[0].matchPackageNames`: Your input contains `*` or `**` along with other patterns. Please remove them, as `*` or `**` matches all patterns.

## Root cause

`matchPackagePatterns` and `excludePackageNames` are both deprecated. Renovate's config migration collapses them into a single key:

```json
"matchPackageNames": ["*", "!python"]
```

`*` is a special value meaning "match everything" and cannot be combined with any other pattern — so the migrated config is invalid. That's why the error names a key the file didn't literally contain.

## Fix

Use the negation-only form. A match succeeds when at least one positive pattern matches (vacuously true when there are none) and no negative pattern matches, so every package is still grouped except `python` — same behaviour as before.

```diff
-      "matchPackagePatterns": [
-        "*"
+      "matchPackageNames": [
+        "!python"
       ],
-      "excludePackageNames": ["python"],
```

## Verification

`renovate-config-validator` reproduces the reported error on the old config and passes on the new one:

```
$ npx --package renovate renovate-config-validator old-renovate.json
ERROR: Found errors in configuration
       "message": "packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns. ..."

$ npx --package renovate renovate-config-validator renovate.json
 INFO: Config validated successfully against 1 file(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJb27fB7d7HbQqfXc7U66V